### PR TITLE
Create github actions for faster CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,7 +44,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools
+          python -m pip install --upgrade pip setuptools wheel
           python -m pip install -r requirements-dev.txt
 
       - name: Install standard onnx

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,7 +58,7 @@ jobs:
         run: python setup.py sdist
 
       - name: pytest
-        run: pytest -v onnxscript --cov=onnxscript --cov-report=xml
+        run: pytest -v onnxscript --cov=onnxscript --cov-report=xml -n auto
 
       - name: Install package
         run: pip install .

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Python310-onnx:
+          - python-version: "3.10"
+            onnx_standard: true
+            test_examples: true
+          # Python39-onnx:
+          - python-version: "3.9"
+            onnx_standard: true
+            test_examples: false
+          # Python39-expe:
+          - python-version: "3.9"
+            onnx_standard: false
+            test_examples: false
+          # Python38-expe:
+          - python-version: "3.8"
+            onnx_standard: false
+            test_examples: false
+          # Python37-expe:
+          - python-version: "3.7"
+            onnx_standard: false
+            test_examples: false
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install -r requirements-dev.txt
+
+      - name: Install standard onnx
+        if: ${{ matrix.onnx_standard }}
+        run: |
+            python -m pip uninstall -y onnx-function-experiment
+            python -m pip uninstall -y ort-function-experiment-nightly
+            python -m pip install onnx onnxruntime
+
+      - name: Make package
+        run: python setup.py sdist
+
+      - name: pytest
+        run: pytest -v onnxscript --cov=onnxscript --cov-report term-missing
+
+      - name: Install package
+        run: pip install .
+
+      - name: Test examples
+        if: ${{ matrix.test_examples }}
+        run: pytest -v docs/test
+
+      - name: Build documentation
+        run: python -m sphinx docs dist/html

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,7 +58,7 @@ jobs:
         run: python setup.py sdist
 
       - name: pytest
-        run: pytest -v onnxscript --cov=onnxscript --cov-report term-missing
+        run: pytest -v onnxscript --cov=onnxscript --cov-report=xml
 
       - name: Install package
         run: pip install .
@@ -69,3 +69,6 @@ jobs:
 
       - name: Build documentation
         run: python -m sphinx docs dist/html
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,9 +51,9 @@ jobs:
       - name: Install standard onnx
         if: ${{ matrix.onnx_standard }}
         run: |
-            python -m pip uninstall -y onnx-function-experiment
-            python -m pip uninstall -y ort-function-experiment-nightly
-            python -m pip install onnx onnxruntime
+          python -m pip uninstall -y onnx-function-experiment
+          python -m pip uninstall -y ort-function-experiment-nightly
+          python -m pip install onnx onnxruntime
 
       - name: Make package
         run: python setup.py sdist

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,6 @@ jobs:
         uses: actions/setup-python@v4.2.0
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,8 +38,7 @@ steps:
   displayName: 'Use Python $(python.version)'
 
 - script: |
-    python -m pip install --upgrade pip
-    python -m pip install --upgrade setuptools
+    python -m pip install --upgrade pip setuptools wheel
     python -m pip install -r requirements-dev.txt
   displayName: 'Install dependencies'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,5 +24,6 @@ flake8
 mypy
 black
 isort
+colorama
 dlint
 flake8-bugbear

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,10 +21,10 @@ parameterized
 torch
 
 # Lint
-flake8==5.0.4
-mypy==0.981
-black==22.8.0
-isort==5.10.1
-colorama==0.4.5
-dlint==0.13.0
-flake8-bugbear==22.9.23
+flake8>=5.0.4
+mypy>=0.981
+black>=22.8.0
+isort>=5.10.1
+colorama>=0.4.5
+dlint>=0.13.0
+flake8-bugbear>=22.9.23

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,6 +23,6 @@ torch
 flake8
 mypy
 black
-isort[colors]
+isort
 dlint
 flake8-bugbear

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ torch
 flake8
 mypy
 black
-isort
+isort>=5.10.1
 colorama==0.4.5
 dlint
 flake8-bugbear

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,11 +10,15 @@ protobuf<4
 sphinx
 sphinx-gallery
 pydata_sphinx_theme
+
+# Testing
 pytest!=7.1.0
 pytest-cov
 pytest-azurepipelines
 pytest-subtests
+pytest-xdist
 torch
+
 # Lint
 flake8
 mypy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,10 +20,10 @@ pytest-xdist
 torch
 
 # Lint
-flake8
-mypy
-black
+flake8>=5.0.4
+mypy>=0.981
+black>=22.8.0
 isort>=5.10.1
-colorama==0.4.5
-dlint
-flake8-bugbear
+colorama>=0.4.5
+dlint>=0.13.0
+flake8-bugbear>=22.9.23

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,6 +17,7 @@ pytest-cov
 pytest-azurepipelines
 pytest-subtests
 pytest-xdist
+parameterized
 torch
 
 # Lint

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,6 +24,6 @@ flake8
 mypy
 black
 isort
-colorama
+colorama==0.4.5
 dlint
 flake8-bugbear

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,10 +20,10 @@ pytest-xdist
 torch
 
 # Lint
-flake8>=5.0.4
-mypy>=0.981
-black>=22.8.0
-isort>=5.10.1
-colorama>=0.4.5
-dlint>=0.13.0
-flake8-bugbear>=22.9.23
+flake8==5.0.4
+mypy==0.981
+black==22.8.0
+isort==5.10.1
+colorama==0.4.5
+dlint==0.13.0
+flake8-bugbear==22.9.23


### PR DESCRIPTION
Fixes #141 #142 

- Replicate tests run in ADO to github actions
- Use pytest-xdist to enable parallel testing
- Install `wheel` in the test environments
