### PR TITLE
Add flake8-pyi linter

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,3 +28,4 @@ isort>=5.10.1
 colorama>=0.4.5
 dlint>=0.13.0
 flake8-bugbear>=22.9.23
+flake8-pyi>=22.8.2


### PR DESCRIPTION
https://pypi.org/project/flake8-pyi/ catches errors in pyi stubs. We don't have pyi's yet but it's good to have the check in place.