### PR TITLE
Limit action permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,18 +11,8 @@ jobs:
     name: Lint Python
     runs-on: ubuntu-latest
     permissions:
-      actions: write
-      checks: write
-      contents: write
-      deployments: none
-      id-token: write
-      issues: none
-      discussions: none
-      packages: none
       pull-requests: write
-      repository-projects: none
-      security-events: none
-      statuses: read
+
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python


### PR DESCRIPTION
Minimally needed permissions for actions.

Ref: https://docs.github.com/en/rest/overview/permissions-required-for-github-apps#permission-on-pull-requests