### PR TITLE
Move build documentation to a separate CI job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,10 +11,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         include:
           # Python310-onnx:
           - python-version: "3.10"
@@ -36,12 +36,15 @@ jobs:
           - python-version: "3.7"
             onnx_standard: false
             test_examples: false
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4.2.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: "**/requirements-dev.txt"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
@@ -71,13 +74,19 @@ jobs:
         uses: codecov/codecov-action@v3
 
   build_docs:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4.2.0
         with:
           python-version: "3.10"
+          cache: pip
+          cache-dependency-path: "**/requirements-dev.txt"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,11 +82,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install -r requirements-dev.txt
-      - name: Install standard onnx
-        run: |
-          python -m pip uninstall -y onnx-function-experiment
-          python -m pip uninstall -y ort-function-experiment-nightly
-          python -m pip install onnx onnxruntime
       - name: Install package
         run: pip install .
       - name: Build documentation

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -87,5 +87,7 @@ jobs:
           python -m pip uninstall -y onnx-function-experiment
           python -m pip uninstall -y ort-function-experiment-nightly
           python -m pip install onnx onnxruntime
+      - name: Install package
+        run: pip install .
       - name: Build documentation
         run: python -m sphinx docs dist/html

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,10 +16,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         include:
-          # Python311-onnx:
-          - python-version: "3.11"
-            onnx_standard: true
-            test_examples: true
           # Python310-onnx:
           - python-version: "3.10"
             onnx_standard: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,6 +16,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         include:
+          # Python311-onnx:
+          - python-version: "3.11"
+            onnx_standard: true
+            test_examples: true
           # Python310-onnx:
           - python-version: "3.10"
             onnx_standard: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -67,8 +67,25 @@ jobs:
         if: ${{ matrix.test_examples }}
         run: pytest -v docs/test
 
-      - name: Build documentation
-        run: python -m sphinx docs dist/html
-
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+
+  build_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4.2.0
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r requirements-dev.txt
+      - name: Install standard onnx
+        run: |
+          python -m pip uninstall -y onnx-function-experiment
+          python -m pip uninstall -y ort-function-experiment-nightly
+          python -m pip install onnx onnxruntime
+      - name: Build documentation
+        run: python -m sphinx docs dist/html

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,3 @@ steps:
           pytest -v docs/test
       fi
   displayName: 'Test examples'
-
-- script: |
-    python -m sphinx docs dist/html
-  displayName: 'documentation'


### PR DESCRIPTION
Because we only need to build the doc once.

Also

- Add windows machines to test and build doc
- cache pip packages for faster runs