### PR TITLE
fix: move onnxruntime import to function scope

### DIFF
--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -7,18 +7,16 @@ from __future__ import annotations
 import abc
 import contextlib
 import pprint
+import typing
 from typing import Any, Optional
 
 import numpy as np
 import onnx
-import onnxruntime as ort
-from onnxruntime.capi.onnxruntime_pybind11_state import (
-    Fail,
-    InvalidArgument,
-    InvalidGraph,
-)
 
 from onnxscript import autocast, irbuilder, onnx_opset, tensor, utils, values
+
+if typing.TYPE_CHECKING:
+    import onnxruntime as ort
 
 
 class Evaluator(abc.ABC):
@@ -123,6 +121,8 @@ _cache_models: dict[Any, ort.InferenceSession] = {}
 
 
 def _cache_(model, providers):
+    import onnxruntime as ort  # pylint: disable=import-outside-toplevel
+
     serialized = model.SerializeToString()
     key = serialized, tuple(providers)
     if key in _cache_models:
@@ -159,6 +159,12 @@ def ort_to_os_value(v):
 
 
 def call_ort(schema, args, kwargs, implicit_args=None):
+    from onnxruntime.capi.onnxruntime_pybind11_state import (  # pylint: disable=import-outside-toplevel
+        Fail,
+        InvalidArgument,
+        InvalidGraph,
+    )
+
     implicit_args = implicit_args or {}
     # Convert input values to ORT representation-type:
     args = [os_to_ort_value(x) for x in args]

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -262,7 +262,7 @@ class OnnxFunction(Op):
         """Returns the function name."""
         return self.opname
 
-    def __getitem__(self, instance):
+    def __getitem__(self, instance: evaluator.Evaluator):
         """Returns a lambda to evaluate function using given evaluator instance.
 
         Usage:

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -14,7 +14,7 @@ import numpy as np
 import onnx
 from onnx.defs import OpSchema
 
-from onnxscript import irbuilder, sourceinfo, tensor
+from onnxscript import evaluator, irbuilder, sourceinfo, tensor
 
 
 class Opset:
@@ -134,8 +134,6 @@ class Op:
         return kwargs, closure
 
     def __call__(self, *args, **kwargs):
-        from onnxscript import evaluator  # pylint: disable=import-outside-toplevel
-
         return evaluator.eval(self.opschema, args, kwargs)
 
 
@@ -268,13 +266,11 @@ class OnnxFunction(Op):
         """Returns a lambda to evaluate function using given evaluator instance.
 
         Usage:
-           script_fun(X) executes the function using the default evaluator instance.
-           script_fun[instance](X) executes the function using the given evaluator instance.
+            script_fun(X) executes the function using the default evaluator instance.
+            script_fun[instance](X) executes the function using the given evaluator instance.
         """
 
         def fun(*args, **kwargs):
-            from onnxscript import evaluator  # pylint: disable=import-outside-toplevel
-
             with evaluator.default_as(instance):
                 return self.__call__(*args, **kwargs)
 

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -14,7 +14,7 @@ import numpy as np
 import onnx
 from onnx.defs import OpSchema
 
-from onnxscript import evaluator, irbuilder, sourceinfo, tensor
+from onnxscript import irbuilder, sourceinfo, tensor
 
 
 class Opset:
@@ -134,6 +134,8 @@ class Op:
         return kwargs, closure
 
     def __call__(self, *args, **kwargs):
+        from onnxscript import evaluator  # pylint: disable=import-outside-toplevel
+
         return evaluator.eval(self.opschema, args, kwargs)
 
 
@@ -262,7 +264,7 @@ class OnnxFunction(Op):
         """Returns the function name."""
         return self.opname
 
-    def __getitem__(self, instance: evaluator.Evaluator):
+    def __getitem__(self, instance):
         """Returns a lambda to evaluate function using given evaluator instance.
 
         Usage:
@@ -271,6 +273,8 @@ class OnnxFunction(Op):
         """
 
         def fun(*args, **kwargs):
+            from onnxscript import evaluator  # pylint: disable=import-outside-toplevel
+
             with evaluator.default_as(instance):
                 return self.__call__(*args, **kwargs)
 


### PR DESCRIPTION
Move ort import into functions so onnx script still works without ort. This is also more friendly for new potential evaluators that do not require ORT.

fixes: #81 