### PR TITLE
opgen: run lintrunner instead of black/isort

### DIFF
--- a/opgen/__main__.py
+++ b/opgen/__main__.py
@@ -30,8 +30,7 @@ with open(opsets_path.joinpath("__init__.py"), "w", encoding="utf-8"):
 
 builder = OpsetsBuilder(".".join(module_base_names), MIN_REQUIRED_ONNX_OPSET_VERSION)
 paths = builder.write(repo_root)
-subprocess.check_call(["black", "--quiet", *paths])
-subprocess.check_call(["isort", "--quiet", *paths])
+subprocess.check_call(["lintrunner", "-v", "-a", "--skip", "SPACES", *paths])
 
 print(f"Generated Ops: {builder.all_ops_count}")
 


### PR DESCRIPTION
The SPACES linter has some terrible O(N^?) perf when explicitly passing paths that comprise tens of thousands of lines of code, so skip it here. The generator doesn't write lines with trailing spaces anyway.