### PR TITLE
Cleanup use of default opset in converter

### DIFF
--- a/docs/examples/03_export_lib.py
+++ b/docs/examples/03_export_lib.py
@@ -27,7 +27,7 @@ def l2norm(X):
 
 @script(opset)
 def square_loss(X, Y):
-    return l2norm(X - Y)
+    return l2norm(op.Sub(X, Y))
 
 
 #%%

--- a/docs/examples/06_plot_model_local_funs.py
+++ b/docs/examples/06_plot_model_local_funs.py
@@ -23,7 +23,7 @@ from onnxscript.values import Opset
 local = Opset("local", 1)
 
 
-@script(local)
+@script(local, default_opset=op)
 def diff_square(x, y):
     diff = x - y
     return diff * diff

--- a/onnxscript/converter.py
+++ b/onnxscript/converter.py
@@ -183,7 +183,7 @@ class Converter:
     def default_opset(self):
         if self.default_opset_ is None:
             raise RuntimeError(
-                "Default_opset must be specified in script for functions "
+                "default_opset must be specified in script for functions "
                 "that do not contain any use of an ONNX opset."
             )
         return self.default_opset_

--- a/onnxscript/test/functions/ort_custom_ops.py
+++ b/onnxscript/test/functions/ort_custom_ops.py
@@ -40,12 +40,12 @@ def FastGeluGrad(dY, X):
     return dY * grad
 
 
-@script()
+@script(default_opset=op)
 def SigmoidGrad(dY, Y):
     dX = dY * Y * (1.0 - Y)
     return dX
 
 
-@script()
+@script(default_opset=op)
 def TanhGrad(dY, Y):
     return dY * (1.0 - Y * Y)

--- a/onnxscript/test/models/cast_like.py
+++ b/onnxscript/test/models/cast_like.py
@@ -10,7 +10,7 @@ from onnxscript.onnx_opset import opset15 as op
 from onnxscript.onnx_types import BOOL, FLOAT
 
 
-@script()
+@script(default_opset=op)
 def inc_right(A: FLOAT[...]) -> FLOAT[...]:
     return A + 1
 
@@ -20,7 +20,7 @@ def inc_right_expanded(A: FLOAT[...]) -> FLOAT[...]:
     return A + op.CastLike(1, A)
 
 
-@script()
+@script(default_opset=op)
 def inc_left(A: FLOAT[...]) -> FLOAT[...]:
     return 1 + A
 
@@ -30,7 +30,7 @@ def inc_left_expanded(A: FLOAT[...]) -> FLOAT[...]:
     return op.CastLike(1, A) + A
 
 
-@script()
+@script(default_opset=op)
 def cmp_zero_right(A: FLOAT[...]) -> BOOL[...]:
     return A == 0
 
@@ -40,7 +40,7 @@ def cmp_zero_right_expanded(A: FLOAT[...]) -> BOOL[...]:
     return A == op.CastLike(0, A)
 
 
-@script()
+@script(default_opset=op)
 def cmp_zero_mright(A: FLOAT[...]) -> BOOL[...]:
     return A == -11
 
@@ -50,7 +50,7 @@ def cmp_zero_mright_expanded(A: FLOAT[...]) -> BOOL[...]:
     return A == op.CastLike(-11, A)
 
 
-@script()
+@script(default_opset=op)
 def cmp_zero_left(A: FLOAT[...]) -> BOOL[...]:
     return 0 == A
 
@@ -60,7 +60,7 @@ def cmp_zero_left_expanded(A: FLOAT[...]) -> BOOL[...]:
     return op.CastLike(0, A) == A
 
 
-@script()
+@script(default_opset=op)
 def div_right(A: FLOAT[...]) -> FLOAT[...]:
     return A / 2
 
@@ -70,7 +70,7 @@ def div_right_expanded(A: FLOAT[...]) -> FLOAT[...]:
     return A / op.CastLike(2, A)
 
 
-@script()
+@script(default_opset=op)
 def div_minus_right(A: FLOAT[...]) -> FLOAT[...]:
     return A / (-2)
 

--- a/onnxscript/test/models/eager_op.py
+++ b/onnxscript/test/models/eager_op.py
@@ -12,7 +12,7 @@ from onnxscript.onnx_opset import opset15 as op
 from onnxscript.onnx_types import FLOAT
 
 
-@script()
+@script(default_opset=op)
 def eager_op(X: FLOAT[...]) -> FLOAT[...]:
     return X % 1.5
 

--- a/onnxscript/test/models/getitem.py
+++ b/onnxscript/test/models/getitem.py
@@ -11,12 +11,12 @@ from onnxscript.onnx_opset import opset15 as op
 from onnxscript.onnx_types import FLOAT
 
 
-@script()
+@script(default_opset=op)
 def getitem_rev0(A: FLOAT[...]) -> FLOAT[...]:
     return A[0, :0:-1]
 
 
-@script()
+@script(default_opset=op)
 def getitem_rev(A: FLOAT[...]) -> FLOAT[...]:
     return A[:0:-1]
 
@@ -35,25 +35,25 @@ def getitem_index_int0_1(A: FLOAT[...]) -> FLOAT[...]:
     return r
 
 
-@script()
+@script(default_opset=op)
 def getitem_column(A: FLOAT[...]) -> FLOAT[...]:
     r = A[:, 1]
     return r
 
 
-@script()
+@script(default_opset=op)
 def getitem_i_mixed_tuple(A: FLOAT[...]) -> FLOAT[...]:
     r = A[:2, 0]
     return r
 
 
-@script()
+@script(default_opset=op)
 def getitem_i_tuple(A: FLOAT[...]) -> FLOAT[...]:
     r = A[:2, :1]
     return r
 
 
-@script()
+@script(default_opset=op)
 def getitem_i_slice_step(A: FLOAT[...]) -> FLOAT[...]:
     r = A[2:0:-1]
     return r
@@ -68,43 +68,43 @@ def getitem_i_var(A: FLOAT[...]) -> FLOAT[...]:
     return r
 
 
-@script()
+@script(default_opset=op)
 def getitem_i_slice_left(A: FLOAT[...]) -> FLOAT[...]:
     r = A[1:]
     return r
 
 
-@script()
+@script(default_opset=op)
 def getitem_i_slice_right(A: FLOAT[...]) -> FLOAT[...]:
     r = A[:2]
     return r
 
 
-@script()
+@script(default_opset=op)
 def getitem_i_slice_neg(A: FLOAT[...]) -> FLOAT[...]:
     r = A[1:-1]
     return r
 
 
-@script()
+@script(default_opset=op)
 def getitem_i_slice(A: FLOAT[...]) -> FLOAT[...]:
     r = A[1:2]
     return r
 
 
-@script()
+@script(default_opset=op)
 def getitem_i_last(A: FLOAT[...]) -> FLOAT[...]:
     r = A[-1]
     return r
 
 
-@script()
+@script(default_opset=op)
 def getitem_i(A: FLOAT[...]) -> FLOAT[...]:
     r = A[0]
     return r
 
 
-@script()
+@script(default_opset=op)
 def getitem_i_expr(A: FLOAT[...]) -> FLOAT[...]:
     r = (A + 1)[0]
     return r

--- a/onnxscript/test/models/identity.py
+++ b/onnxscript/test/models/identity.py
@@ -10,7 +10,7 @@ from onnxscript.onnx_opset import opset15 as op
 from onnxscript.onnx_types import BOOL, FLOAT, INT64
 
 
-@script()
+@script(default_opset=op)
 def id1(A: FLOAT[...]) -> FLOAT[...]:
     return A  # treat as op.Identity(A)
 
@@ -18,7 +18,7 @@ def id1(A: FLOAT[...]) -> FLOAT[...]:
 def id1_expanded(A: FLOAT[...]) -> FLOAT[...]:
     return op.Identity(A)
 
-@script()
+@script(default_opset=op)
 def id2(A: FLOAT[...]) -> FLOAT[...]:
     B = A
     return B  # treat as op.Identity(B) == op.Identity(A)

--- a/onnxscript/test/operator_test.py
+++ b/onnxscript/test/operator_test.py
@@ -16,8 +16,8 @@ from onnxscript.test.common import testutils
 class TestConverter(testutils.TestBase):
     def test_plus_op(self):
         """Test that + is translated to Add op."""
-        # TODO: pass default opset as parameter to @script
-        @script()
+
+        @script(default_opset=op)
         def plus1(x, y):
             return x + y
 


### PR DESCRIPTION
A script function should implicitly or explicitly indicate which ONNX opset version it uses.

This PR adds a search in the converter to identify any implicit use of an ONNX opset (indicated by a call to `someopset.OpName(...)`) first. The identified opset is used, for example, in translation of overloaded operators.

For a function that contains no such call (for example, one that uses only overloaded operators such as + and *), the script parameter should specify the default_opset to use. 

Cleanup all examples where a default needs to be specified.