### PR TITLE
Add input parameter names to used vars

### DIFF
--- a/onnxscript/converter.py
+++ b/onnxscript/converter.py
@@ -1304,6 +1304,7 @@ class Converter:
                 self.bind(x.arg, values.AttrRef(x.arg, typeinfo, self.source_of(x)))
             else:
                 self.ir_builder.add_input(self.current_fn, x.arg, typeinfo, self.source_of(x))
+                self.used_vars.add(x.arg)
                 self.bind(
                     x.arg,
                     values.Dynamic(x.arg, values.DynamicKind.Input, self.source_of(x)),

--- a/onnxscript/test/converter_test.py
+++ b/onnxscript/test/converter_test.py
@@ -612,8 +612,10 @@ class TestConverter(testutils.TestBase):
         def model_script(x: FLOAT[100]) -> FLOAT[100]:
             x = op.Add(x, x)
             return x
+
         proto = model_script.to_model_proto()
         onnx.shape_inference.infer_shapes(proto)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/onnxscript/test/converter_test.py
+++ b/onnxscript/test/converter_test.py
@@ -607,6 +607,13 @@ class TestConverter(testutils.TestBase):
 
         self.validate_run(attr_test)
 
+    def test_renaming_parameter(self):
+        @script()
+        def model_script(x: FLOAT[100]) -> FLOAT[100]:
+            x = op.Add(x, x)
+            return x
+        proto = model_script.to_model_proto()
+        onnx.shape_inference.infer_shapes(proto)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
The unique-name generation mechanism does not take input parameters into account. Fix this bug.

Fixes https://github.com/microsoft/onnx-script/issues/242