### PR TITLE
fix: annotate script()

### DIFF
--- a/onnxscript/main.py
+++ b/onnxscript/main.py
@@ -9,6 +9,7 @@ import ast
 import inspect
 import sys
 import textwrap
+from typing import Any, Callable, Optional
 
 import onnx.helper
 
@@ -52,7 +53,9 @@ def script_check(f: ast.FunctionDef, opset, global_names, source, default_opset=
     return convert.top_level_stmt(f)
 
 
-def script(opset=None, default_opset=None, **kwargs):
+def script(
+    opset: Optional[values.Opset] = None, default_opset: Optional[Any] = None, **kwargs: Any
+) -> Callable[[Callable[..., Any]], onnxscript.OnnxFunction]:
     """Main decorator. Declares a function as an onnx function.
 
     Args:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

To allow mypy to analyze typing for annotated functions. Otherwise it complains that "Untyped decorator makes function "ones_like" untyped  [misc]"