### PR TITLE
feat(atenlib): atenlib function registry

### DIFF
--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from typing import Any, Optional, Sequence
 
 from onnxscript import BOOL, INT64
+from onnxscript.function_libs.torch_aten.registration import torch_op
 from onnxscript.onnx_opset import opset18 as op
 from onnxscript.onnx_types import TensorType
 
@@ -3129,12 +3130,14 @@ def aten_msort(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-def aten_mul(self, other) -> TensorType:
+@torch_op("aten::mul")
+def aten_mul(self, other):
     # mul.Tensor(Tensor self, Tensor other) -> Tensor
 
     return op.Mul(self, other)
 
 
+@torch_op("aten::mul", overload=True)
 def aten_mul_bool(self: BOOL, other: BOOL) -> BOOL:
     """ONNX Mul doesn't support Boolean, so use And as an equivalent operator."""
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -740,6 +740,7 @@ def aten_chunk(self: TensorType, chunks: int, dim: int = 0) -> TensorType:
     raise NotImplementedError()
 
 
+@torch_op("aten::clamp")
 def aten_clamp(self: TensorType, min_=None, max_=None) -> TensorType:
     # clamp(Tensor self, Scalar? min=None, Scalar? max=None) -> Tensor
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -23,18 +23,21 @@ from onnxscript.onnx_opset import opset18 as op
 from onnxscript.onnx_types import TensorType
 
 
+@torch_op("aten::abs")
 def aten_abs(self):
     # abs(Tensor self) -> Tensor
 
     return op.Abs(self)
 
 
+@torch_op("aten::acos")
 def aten_acos(self):
     # acos(Tensor self) -> Tensor
 
     return op.Acos(self)
 
 
+@torch_op("aten::acosh")
 def aten_acosh(self):
     # acosh(Tensor self) -> Tensor
 
@@ -55,6 +58,7 @@ def aten_adaptive_max_pool1d(
     raise NotImplementedError()
 
 
+@torch_op("aten::add")
 def aten_add(self, other, alpha: float = 1) -> TensorType:
     # add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
     if alpha != 1:
@@ -86,6 +90,7 @@ def aten_addcmul(
     raise NotImplementedError()
 
 
+@torch_op("aten::addmm")
 def aten_addmm(self, mat1, mat2, beta: float = 1, alpha: float = 1):
     # addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
@@ -333,18 +338,21 @@ def aten_as_strided_scatter(
     raise NotImplementedError()
 
 
+@torch_op("aten::asin")
 def aten_asin(self):
     # asin(Tensor self) -> Tensor
 
     return op.Asin(self)
 
 
+@torch_op("aten::asinh")
 def aten_asinh(self):
     # asinh(Tensor self) -> Tensor
 
     return op.Asinh(self)
 
 
+@torch_op("aten::atan")
 def aten_atan(self):
     # atan(Tensor self) -> Tensor
 
@@ -357,6 +365,7 @@ def aten_atan2(self: TensorType, other: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
+@torch_op("aten::atanh")
 def aten_atanh(self):
     # atanh(Tensor self) -> Tensor
 
@@ -607,6 +616,7 @@ def aten_block_diag(tensors: Sequence[TensorType]) -> TensorType:
     raise NotImplementedError()
 
 
+@torch_op("aten::bmm")
 def aten_bmm(self, mat2):
     # bmm(Tensor self, Tensor mat2) -> Tensor
 
@@ -671,6 +681,7 @@ def aten_cdist(
     raise NotImplementedError()
 
 
+@torch_op("aten::ceil")
 def aten_ceil(self):
     # ceil(Tensor self) -> Tensor
 
@@ -753,6 +764,7 @@ def aten_clamp(self: TensorType, min_=None, max_=None) -> TensorType:
     return clamped
 
 
+@torch_op("aten::clamp_max.Scalar", overload=True)
 def aten_clamp_max_scalar(self, max_):
     # clamp_max(Tensor self, Scalar max) -> Tensor
 
@@ -760,12 +772,14 @@ def aten_clamp_max_scalar(self, max_):
     return op.Clip(self, None, max_)
 
 
+@torch_op("aten::clamp_max.Tensor")
 def aten_clamp_max_tensor(self, max_):
-    # clamp_max(Tensor self, Scalar max) -> Tensor
+    # clamp_max(Tensor self, Tensor max) -> Tensor
 
     return op.Min(self, max_)
 
 
+@torch_op("aten::clamp_min.Scalar", overload=True)
 def aten_clamp_min_scalar(self, min_):
     # clamp_min(Tensor self, Scalar min) -> Tensor
     # NOTE: min_ is a rank 0 tensor.
@@ -774,6 +788,7 @@ def aten_clamp_min_scalar(self, min_):
     return op.Clip(self, min_, None)
 
 
+@torch_op("aten::clamp_min.Tensor")
 def aten_clamp_min_tensor(self, min_):
     # clamp_min(Tensor self, Tensor min) -> Tensor
     # TODO(justinchuby): Specify the type constraints.
@@ -1018,12 +1033,14 @@ def aten_corrcoef(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
+@torch_op("aten::cos")
 def aten_cos(self):
     # cos(Tensor self) -> Tensor
 
     return op.Cos(self)
 
 
+@torch_op("aten::cosh")
 def aten_cosh(self):
     # cosh(Tensor self) -> Tensor
 
@@ -1393,6 +1410,7 @@ def aten_divide(self: TensorType, other: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
+@torch_op("aten::dot")
 def aten_dot(self, tensor):
     # dot(Tensor self, Tensor tensor) -> Tensor
 
@@ -1533,12 +1551,14 @@ def aten_erfinv(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
+@torch_op("aten::exp")
 def aten_exp(self):
     # exp(Tensor self) -> Tensor
 
     return op.Exp(self)
 
 
+@torch_op("aten::exp2")
 def aten_exp2(self):
     # exp2(Tensor self) -> Tensor
 
@@ -1973,6 +1993,7 @@ def aten_gru_cell(
     raise NotImplementedError()
 
 
+@torch_op("aten::gt")
 def aten_gt(self, other):
     # gt.Tensor(Tensor self, Tensor other) -> Tensor
 
@@ -2589,6 +2610,7 @@ def aten_lstm_mps_backward(
     raise NotImplementedError()
 
 
+@torch_op("aten::lt")
 def aten_lt(self, other):
     # lt.Tensor(Tensor self, Tensor other) -> Tensor
 
@@ -2664,6 +2686,7 @@ def aten_masked_select_backward(
     raise NotImplementedError()
 
 
+@torch_op("aten::matmul")
 def aten_matmul(self, other):
     # matmul(Tensor self, Tensor other) -> Tensor
 
@@ -3064,6 +3087,7 @@ def aten_mkldnn_max_pool3d_backward(
     raise NotImplementedError()
 
 
+@torch_op("aten::mm")
 def aten_mm(self, mat2):
     # mm(Tensor self, Tensor mat2) -> Tensor
 
@@ -3450,6 +3474,7 @@ def aten_nuclear_norm(self: TensorType, keepdim: bool = False) -> TensorType:
     raise NotImplementedError()
 
 
+@torch_op("aten::ones")
 def aten_ones(size: INT64, dtype: int = -1) -> TensorType:
     # ones(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
@@ -3459,6 +3484,7 @@ def aten_ones(size: INT64, dtype: int = -1) -> TensorType:
     return op.Expand(one, size)  # type: ignore[arg-type]
 
 
+@torch_op("aten::ones_like")
 def aten_ones_like(self, dtype: int = -1):
     """ones_like.
 
@@ -3945,6 +3971,7 @@ def aten_renorm(self: TensorType, p: float, dim: int, maxnorm: float) -> TensorT
     raise NotImplementedError()
 
 
+@torch_op("aten::repeat")
 def aten_repeat(self, repeats: INT64):
     # repeat(Tensor self, SymInt[] repeats) -> Tensor
 
@@ -4050,6 +4077,7 @@ def aten_rot90(self: TensorType, k: int = 1, dims: Sequence[int] = (0, 1)) -> Te
     raise NotImplementedError()
 
 
+@torch_op("aten::round")
 def aten_round(self):
     # round(Tensor self) -> Tensor
 
@@ -4160,6 +4188,7 @@ def aten_select_scatter(self: TensorType, src: TensorType, dim: int, index: int)
     raise NotImplementedError()
 
 
+@torch_op("aten::selu")
 def aten_selu(self):
     # selu(Tensor self) -> Tensor
 
@@ -4196,12 +4225,14 @@ def aten_signbit(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
+@torch_op("aten::sin")
 def aten_sin(self):
     # sin(Tensor self) -> Tensor
 
     return op.Sin(self)
 
 
+@torch_op("aten::sinh")
 def aten_sinh(self):
     # sinh(Tensor self) -> Tensor
 
@@ -4381,6 +4412,7 @@ def aten_stft(
     raise NotImplementedError()
 
 
+@torch_op("aten::sub")
 def aten_sub(self, other, alpha: float = 1) -> TensorType:
     # sub.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
 
@@ -4436,6 +4468,7 @@ def aten_symeig(
     raise NotImplementedError()
 
 
+@torch_op("aten::t")
 def aten_t(self: TensorType) -> TensorType:
     # t(Tensor(a) self) -> Tensor(a)
 
@@ -4468,12 +4501,14 @@ def aten_take_along_dim(
     raise NotImplementedError()
 
 
+@torch_op("aten::tan")
 def aten_tan(self):
     # tan(Tensor self) -> Tensor
 
     return op.Tan(self)
 
 
+@torch_op("aten::tanh")
 def aten_tanh(self):
     # tanh(Tensor self) -> Tensor
 
@@ -4861,6 +4896,7 @@ def aten_xor(self: TensorType, other: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
+@torch_op("aten::zeros")
 def aten_zeros(size, dtype: int = -1):
     # zeros(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
@@ -4871,6 +4907,7 @@ def aten_zeros(size, dtype: int = -1):
     return op.Expand(zero, size)  # type: ignore[arg-type]
 
 
+@torch_op("aten::zeros_like")
 def aten_zeros_like(self, dtype: int = -1):
     # zeros_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 

--- a/onnxscript/function_libs/torch_aten/ops/nn.py
+++ b/onnxscript/function_libs/torch_aten/ops/nn.py
@@ -415,6 +415,7 @@ def aten_leaky_relu_backward(
     raise NotImplementedError()
 
 
+@torch_op("aten::linear")
 def aten_linear(input, weight, bias=None) -> TensorType:
     # linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor
 

--- a/onnxscript/function_libs/torch_aten/ops/nn.py
+++ b/onnxscript/function_libs/torch_aten/ops/nn.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import Optional, Sequence
 
 from onnxscript import INT64
+from onnxscript.function_libs.torch_aten.registration import torch_op
 from onnxscript.onnx_opset import opset18 as op
 from onnxscript.onnx_types import TensorType
 
@@ -196,6 +197,7 @@ def aten_cross_entropy_loss(
     raise NotImplementedError()
 
 
+@torch_op("aten::elu")
 def aten_elu(
     self,
     alpha: float = 1.0,
@@ -800,6 +802,7 @@ def aten_reflection_pad3d_backward(
 
 
 # TODO(justinchuby): Use TFloat as return type
+@torch_op("aten::relu6")
 def aten_relu6(self):
     # relu6(Tensor self) -> Tensor
 

--- a/onnxscript/function_libs/torch_aten/registration.py
+++ b/onnxscript/function_libs/torch_aten/registration.py
@@ -39,12 +39,6 @@ class Registry:
     def __iter__(self):
         return iter(self._registry)
 
-    def __len__(self):
-        return len(self._registry)
-
-    def __str__(self):
-        return str(self._registry)
-
     def __repr__(self):
         return repr(self._registry)
 

--- a/onnxscript/function_libs/torch_aten/registration.py
+++ b/onnxscript/function_libs/torch_aten/registration.py
@@ -1,0 +1,75 @@
+"""Registry for aten functions."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+import onnxscript
+
+
+class OverloadedFunction:
+    """Overloaded function."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.default: Optional[Any] = None
+        self.overloads: list[Any] = []
+
+
+class Registry:
+    """Registry for aten functions."""
+
+    def __init__(self):
+        self._registry: dict[str, OverloadedFunction] = {}
+
+    def register(self, name: str, overload: bool = False):
+        """Register a function."""
+
+        def wrapper(func):
+            if overload:
+                self._registry.setdefault(name, OverloadedFunction(name)).overloads.append(
+                    func
+                )
+            else:
+                self._registry.setdefault(name, OverloadedFunction(name)).default = func
+            return func
+
+        return wrapper
+
+    def __getitem__(self, name):
+        return self._registry[name]
+
+    def __contains__(self, name):
+        return name in self._registry
+
+    def __iter__(self):
+        return iter(self._registry)
+
+    def __len__(self):
+        return len(self._registry)
+
+    def __str__(self):
+        return str(self._registry)
+
+    def __repr__(self):
+        return repr(self._registry)
+
+
+# Default registry
+default_registry = Registry()
+
+
+def torch_op(name, overload: bool = False, registry: Optional[Registry] = None):
+    """Register a torch op."""
+    if registry is None:
+        registry = default_registry
+
+    def wrapper(func: Callable[..., Any]) -> onnxscript.OnnxFunction:
+
+        # Compile the function
+        compiled = onnxscript.script()(func)
+
+        registry.register(name, overload=overload)(compiled)
+        return compiled
+
+    return wrapper

--- a/onnxscript/function_libs/torch_aten/registration.py
+++ b/onnxscript/function_libs/torch_aten/registration.py
@@ -53,7 +53,9 @@ class Registry:
 default_registry = Registry()
 
 
-def torch_op(name, overload: bool = False, registry: Optional[Registry] = None):
+def torch_op(
+    name, overload: bool = False, registry: Optional[Registry] = None
+) -> Callable[[Callable[..., Any]], onnxscript.OnnxFunction]:
     """Register a torch op."""
     if registry is None:
         registry = default_registry

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -9,7 +9,6 @@ from typing import Any, Callable, Collection, Iterable, Optional, Sequence, Type
 import numpy as np
 import onnx
 import onnxruntime.capi.onnxruntime_pybind11_state
-import parameterized
 import torch
 from torch.testing._internal import common_device_type, common_methods_invocations
 from torch.testing._internal.opinfo import core as opinfo_core

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -160,7 +160,7 @@ def add_decorate_info(
 
 # Ops to be tested for numerical consistency between onnx and pytorch
 # Find the names of the OpInfos in torch/testing/_internal/common_methods_invocations.py
-OPINFO_FUNCTION_MAPPING: dict[str, Callable[..., Any]] = {
+OPINFO_FUNCTION_MAPPING: dict[str, onnxscript.OnnxFunction] = {
     "abs": core_ops.aten_abs,
     "acos": core_ops.aten_acos,
     "acosh": core_ops.aten_acosh,
@@ -401,17 +401,6 @@ TORCH_TYPE_TO_ONNX = {
 }
 
 
-class TestFunctionsCompilation(unittest.TestCase):
-    """Test all functions can be compiled."""
-
-    @parameterized.parameterized.expand(
-        list(OPINFO_FUNCTION_MAPPING.items()),
-    )
-    def test_function_compiles(self, _, function):
-        compiled = onnxscript.script()(function)
-        compiled.to_function_proto()
-
-
 def _convert_tensor_to_numpy(input: Any) -> Any:
     if isinstance(input, torch.Tensor):
         return input.detach().cpu().numpy()
@@ -488,7 +477,6 @@ class TestOutputConsistency(unittest.TestCase):
         )
 
         onnx_function = OPINFO_FUNCTION_MAPPING[op.name]
-        scripted_function = onnxscript.script()(onnx_function)
 
         for (i, cpu_sample) in enumerate(samples):
             inputs = (cpu_sample.input, *cpu_sample.args)
@@ -505,7 +493,7 @@ class TestOutputConsistency(unittest.TestCase):
                 kwargs_onnx = _convert_kwargs_for_onnx(cpu_sample.kwargs)
                 output_torch = op(*inputs, **cpu_sample.kwargs)
                 try:
-                    function_output = scripted_function(*input_onnx, **kwargs_onnx)
+                    function_output = onnx_function(*input_onnx, **kwargs_onnx)
                 # pylint: disable=c-extension-no-member
                 except onnxruntime.capi.onnxruntime_pybind11_state.NotImplemented:
                     self.skipTest(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #260

Registry for all atenlib functions, which supports overloading. This change implements the `torch_op` decorator for registering all functions in the ATen lib so they are discoverable. It is not designed to be used by users, but rather as an info container so code gen knows which ops are implemented.

`torch_op` also compiles the functions into OnnxFunction.