### PR TITLE
fix(atenlib): merge aten_clamp_min/max tensor and scalar version; repeat

### DIFF
--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -3983,16 +3983,18 @@ def aten_renorm(self: TensorType, p: float, dim: int, maxnorm: float) -> TensorT
 def aten_repeat(self, repeats: INT64):
     # repeat(Tensor self, SymInt[] repeats) -> Tensor
 
-    # FIXME(justinchuby): When repeats.shape == [0]
-
-    # TODO(justinchuby): Make ones_like a function when onnxscript supports it
-    # shape = ones_like(repeats) := {
-    one = op.Constant(value_int=1)
-    repeats_shape = op.Shape(repeats)
-    shape = op.Expand(one, repeats_shape)
-    # }
-    self_expanded = op.Expand(self, shape)  # type: ignore[arg-type]
-    return op.Tile(self_expanded, repeats)
+    if op.Size(repeats) == 0:
+        result = self
+    else:
+        # TODO(justinchuby): Make ones_like a function when onnxscript supports it
+        # shape = ones_like(repeats) := {
+        one = op.Constant(value_int=1)
+        repeats_shape = op.Shape(repeats)
+        shape = op.Expand(one, repeats_shape)
+        # }
+        self_expanded = op.Expand(self, shape)  # type: ignore[arg-type]
+        result = op.Tile(self_expanded, repeats)
+    return result
 
 
 def aten_repeat_interleave(

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -4599,8 +4599,8 @@ def aten_trace_backward(grad: TensorType, sizes: INT64) -> TensorType:
 def aten_transpose(self, dim0: int, dim1: int):
     # transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)
 
-    perm = op.SequenceConstruct(dim0, dim1)  # type: ignore[arg-type]
-    return op.Transpose(self, perm)  # type: ignore[arg-type]
+    # FIXME(justinchuby): onnxscript raises Unsupported expression type
+     return op.Transpose(self, [dim0, dim1])
 
 
 def aten_triangular_solve(

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -218,7 +218,6 @@ def aten_aminmax(
 
 def aten_and(self: TensorType, other: TensorType) -> TensorType:
     # __and__.Tensor(Tensor self, Tensor other) -> Tensor
-    
 
     raise NotImplementedError()
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -765,7 +765,7 @@ def aten_clamp(self: TensorType, min_=None, max_=None) -> TensorType:
     return clamped
 
 
-@torch_op("aten::clamp_max", overload=True)
+@torch_op("aten::clamp_max")
 def aten_clamp_max(self, max_):
     # clamp_max(Tensor self, Tensor max) -> Tensor
 
@@ -784,7 +784,7 @@ def aten_clamp_max(self, max_):
     return result
 
 
-@torch_op("aten::clamp_min", overload=True)
+@torch_op("aten::clamp_min")
 def aten_clamp_min(self, min_):
     # clamp_min(Tensor self, Tensor min) -> Tensor
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -4600,7 +4600,7 @@ def aten_transpose(self, dim0: int, dim1: int):
     # transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)
 
     # FIXME(justinchuby): onnxscript raises Unsupported expression type
-     return op.Transpose(self, [dim0, dim1])
+    return op.Transpose(self, [dim0, dim1])
 
 
 def aten_triangular_solve(

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -79,7 +79,7 @@ def xfail(
     *,
     reason: str,
     dtypes: Optional[Collection[torch.dtype]] = None,
-):
+) -> DecorateMeta:
     """Expects an OpInfo test to fail.
 
     Args:
@@ -104,7 +104,7 @@ def skip(
     reason: str,
     dtypes: Optional[Collection[torch.dtype]] = None,
     matcher: Optional[Callable[[Any], Any]] = None,
-):
+) -> DecorateMeta:
     """Skips an OpInfo test.
 
     Args:
@@ -355,7 +355,7 @@ EXPECTED_SKIPS_OR_FAILS = (
 )
 
 
-SKIP_SUBTESTS = ()
+SKIP_SUBTESTS: tuple[DecorateMeta, ...] = ()
 OP_WITH_SKIPPED_SUBTESTS = frozenset(meta.op_name for meta in SKIP_SUBTESTS)
 
 # END OF SECTION TO MODIFY #####################################################

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -172,8 +172,8 @@ OPINFO_FUNCTION_MAPPING: dict[str, Callable[..., Any]] = {
     "atanh": core_ops.aten_atanh,
     "bmm": core_ops.aten_bmm,
     "ceil": core_ops.aten_ceil,
-    "clamp_max": core_ops.aten_clamp_max_tensor,
-    "clamp_min": core_ops.aten_clamp_min_tensor,
+    "clamp_max": core_ops.aten_clamp_max,
+    "clamp_min": core_ops.aten_clamp_min,
     "clamp": core_ops.aten_clamp,
     "cos": core_ops.aten_cos,
     "cosh": core_ops.aten_cosh,
@@ -357,16 +357,6 @@ EXPECTED_SKIPS_OR_FAILS = (
 
 
 SKIP_SUBTESTS = (
-    skip(
-        "clamp_max",
-        reason="Empty tensor not yet supported",
-        matcher=lambda sample: sample.input.size() == torch.Size([0]),
-    ),
-    skip(
-        "clamp_min",
-        reason="Empty tensor not yet supported",
-        matcher=lambda sample: sample.input.size() == torch.Size([0]),
-    ),
     skip(
         "repeat",
         reason="repeating when input is a scalar and repeats is empty is not supported",

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -355,13 +355,7 @@ EXPECTED_SKIPS_OR_FAILS = (
 )
 
 
-SKIP_SUBTESTS = (
-    skip(
-        "repeat",
-        reason="repeating when input is a scalar and repeats is empty is not supported",
-        matcher=lambda sample: sample.args[0] == (),
-    ),
-)
+SKIP_SUBTESTS = ()
 OP_WITH_SKIPPED_SUBTESTS = frozenset(meta.op_name for meta in SKIP_SUBTESTS)
 
 # END OF SECTION TO MODIFY #####################################################

--- a/requirements-onnx.txt
+++ b/requirements-onnx.txt
@@ -1,5 +1,6 @@
 # Requirements for testing with the release version of onnx and onnxruntime
 
 # TODO(#249): Fix tests for onnx 1.13
+numpy==1.21.5
 onnx==1.12
 onnxruntime


### PR DESCRIPTION
- Merge `aten_clamp_min`, `aten_clamp_max`'s scalar and tensor versions by adding logic on the input rank.
- Fix repeat on the empty `repeats` case.

Reviewers: please merge if approved