### PR TITLE
Fix type annotation issue of Sequence and fix a list issue in eager mode.

### DIFF
--- a/onnxscript/type_annotation.py
+++ b/onnxscript/type_annotation.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 from __future__ import annotations
 
+import collections
 import inspect
 import typing
 
@@ -24,7 +25,7 @@ _LISTTYPE_TO_ATTRTYPE_MAP = {
     str: onnx.AttributeProto.STRINGS,
 }
 
-_LIST_CONSTRUCTORS = [list, typing.List, typing.Sequence]
+_LIST_CONSTRUCTORS = [list, typing.List, typing.Sequence, collections.abc.Sequence]
 
 
 def pytype_to_attrtype(pytype: type) -> typing.Optional[onnx.AttributeProto.AttributeType]:

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -207,7 +207,7 @@ def _adapt_to_eager_mode(inputs: ExtendedModeValue) -> EagerModeValue:
         elif input is None:
             return None
         elif isinstance(input, list):
-            return [adapt(elt) for elt in input]
+            return input
         elif isinstance(input, tuple):
             return tuple(adapt(elt) for elt in input)
         raise TypeError(f"Unexpected input type {type(input)}.")


### PR DESCRIPTION
1. While calling pytepe_to_attrtype() function, the annotation of typing.Sequence will be identified to collections.abc.Sequence by get_origin(). This will impact the further execution, so adding collections.abc.Sequence into the _LIST_CONSTRUCTORS.
2. While calling a function in eager mode, a list type of input should not be transformed to be a Tensor list. Update the code logic accordingly.