### PR TITLE
feat(atenlib): index_select; trace_only ops

### DIFF
--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -4687,7 +4687,20 @@ def aten_transpose(self, dim0: int, dim1: int):
 
     # FIXME(justinchuby): onnxscript raises Unsupported expression type
     # Script the function when this is fixed
-    return op.Transpose(self, [dim0, dim1])
+    self_rank = op.Size(op.Shape(self))
+
+    if self_rank == 0:
+        result = self
+    else:
+        # Python code, change when onnxscript supports this
+        self_rank_val = self_rank.value  # type: ignore[attr-defined]
+        dims = list(range(self_rank_val))
+        dims[dim0], dims[dim1] = dims[dim1], dims[dim0]
+        # Python code ends
+
+        result = op.Transpose(self, perm=dims)
+
+    return result
 
 
 def aten_triangular_solve(

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 
 from typing import Any, Optional, Sequence, Union
 
-import onnx.helper
-
 from onnxscript import BOOL, DOUBLE, FLOAT, INT64
 from onnxscript.function_libs.torch_aten.registration import torch_op
 from onnxscript.function_libs.torch_aten.typing import (
@@ -2180,14 +2178,10 @@ def aten_index_reduce(
 def aten_index_select(self: TTensor, dim: int, index: TInt) -> TTensor:
     # index_select(Tensor self, int dim, Tensor index) -> Tensor
 
-    if op.Size(op.Shape(index)) == 0:
-        # Index is a scalar. Reshape it to a size 1 tensor.
-        index = op.Expand(
-            index,
-            op.Constant(value=onnx.helper.make_tensor("size_one", INT64.dtype, [1], [1])),
-        )
-
+    # Index can be a scalar. Reshape it to a rank 1 tensor.
+    index = op.Reshape(index, (-1,))
     index = op.Cast(index, to=INT64.dtype)
+
     return op.Gather(self, index, axis=dim)
 
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -2165,7 +2165,8 @@ def aten_index_reduce(
     raise NotImplementedError()
 
 
-@torch_op("aten::index_select", trace_only=True)  # FIXME(#277): Script when attributes can come before inputs
+# FIXME(#277): Script when attributes can come before inputs
+@torch_op("aten::index_select", trace_only=True)
 def aten_index_select(self: TTensor, dim: int, index: TInt) -> TTensor:
     # index_select(Tensor self, int dim, Tensor index) -> Tensor
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -2174,12 +2174,15 @@ def aten_index_reduce(
     raise NotImplementedError()
 
 
-@torch_op("aten::index_select")
+# @torch_op("aten::index_select")
 def aten_index_select(self: TTensor, dim: int, index: TInt) -> TTensor:
     # index_select(Tensor self, int dim, Tensor index) -> Tensor
 
+    if op.Size(op.Shape(self)) == 0:
+        return self
+
     # Index can be a scalar. Reshape it to a rank 1 tensor.
-    index = op.Reshape(index, (-1,))
+    index = op.Reshape(index, op.Constant(value_floats=[-1]))
     index = op.Cast(index, to=INT64.dtype)
 
     return op.Gather(self, index, axis=dim)

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 
 from typing import Any, Optional, Sequence, Union
 
-from onnxscript import BOOL, DOUBLE, FLOAT, INT64
 import onnx.helper
+
+from onnxscript import BOOL, DOUBLE, FLOAT, INT64
 from onnxscript.function_libs.torch_aten.registration import torch_op
 from onnxscript.function_libs.torch_aten.typing import (
     TFloat,
@@ -2183,9 +2184,7 @@ def aten_index_select(self: TTensor, dim: int, index: TInt) -> TTensor:
         # Index is a scalar. Reshape it to a size 1 tensor.
         index = op.Expand(
             index,
-            op.Constant(
-                value=onnx.helper.make_tensor("size_one", INT64.dtype, [1], [1])
-            ),
+            op.Constant(value=onnx.helper.make_tensor("size_one", INT64.dtype, [1], [1])),
         )
 
     index = op.Cast(index, to=INT64.dtype)

--- a/onnxscript/function_libs/torch_aten/registration.py
+++ b/onnxscript/function_libs/torch_aten/registration.py
@@ -48,19 +48,33 @@ default_registry = Registry()
 
 
 def torch_op(
-    name, overload: bool = False, registry: Optional[Registry] = None
-) -> Callable[[Callable[..., Any]], onnxscript.OnnxFunction]:
-    """Register a torch op."""
+    name,
+    *,
+    overload: bool = False,
+    registry: Optional[Registry] = None,
+    trace_only: bool = False,
+) -> Callable[[Callable[..., Any]], onnxscript.OnnxFunction | Callable[..., Any]]:
+    """Register a torch op.
+
+    Args:
+        name: ATen name of the function. E.g. "aten::add".
+        overload: Whether the function is an overload (not default).
+        registry: Registry to register the function to. If None, the default registry is used.
+        trace_only: Whether the function should only be traced and not compiled.
+    """
     if registry is None:
         registry = default_registry
 
-    def wrapper(func: Callable[..., Any]) -> onnxscript.OnnxFunction:
+    def wrapper(func: Callable[..., Any]) -> onnxscript.OnnxFunction | Callable[..., Any]:
 
-        # Compile the function
-        compiled = onnxscript.script()(func)
+        if trace_only:
+            processed_func = func
+        else:
+            # Compile the function
+            processed_func = onnxscript.script()(func)
 
         assert registry is not None
-        registry.register(compiled, name, overload=overload)
-        return compiled
+        registry.register(processed_func, name, overload=overload)
+        return processed_func
 
     return wrapper

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -366,6 +366,10 @@ class TestOutputConsistency(unittest.TestCase):
                     rtol = None
                     atol = None
 
+                if not isinstance(function_output, np.ndarray):
+                    # An onnxscript tensor
+                    function_output = function_output.value
+
                 # Use torch testing to ensure dtypes and shapes match
                 torch.testing.assert_close(
                     torch.tensor(function_output),

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -278,7 +278,6 @@ EXPECTED_SKIPS_OR_FAILS = (
     xfail("round", variant_name="decimals_0", reason="The op does not support decimals"),
     xfail("round", variant_name="decimals_3", reason="The op does not support decimals"),
     xfail("round", variant_name="decimals_neg_3", reason="The op does not support decimals"),
-    xfail("transpose", reason="Enable when onnxscript errors are fixed"),
 )
 
 

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -182,6 +182,7 @@ def _upsample_kwargs_wrangler(kwargs: dict[str, Any]) -> dict[str, Any]:
 OPINFO_FUNCTION_MAPPING: dict[
     str,
     onnxscript.OnnxFunction
+    | Callable[..., Any]
     | tuple[
         onnxscript.OnnxFunction | Callable[..., Any],
         Callable[[dict[str, Any]], dict[str, Any]],
@@ -253,7 +254,7 @@ OPINFO_FUNCTION_MAPPING: dict[
     "t": core_ops.aten_t,
     "tan": core_ops.aten_tan,
     "tanh": core_ops.aten_tanh,
-    # "transpose": core_ops.aten_transpose,  # TODO(justinchuby): Enable when onnxscript errors are fixed,
+    "transpose": core_ops.aten_transpose,
     "unsqueeze": core_ops.aten_unsqueeze,
     "where": core_ops.aten_where,
     "zeros": core_ops.aten_zeros,

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -170,6 +170,7 @@ OPINFO_FUNCTION_MAPPING: dict[str, onnxscript.OnnxFunction] = {
     "exp2": core_ops.aten_exp2,
     "fmod": core_ops.aten_fmod,
     "gt": core_ops.aten_gt,
+    "index_select": core_ops.aten_index_select,
     "isinf": core_ops.aten_isinf,
     "lt": core_ops.aten_lt,
     "matmul": core_ops.aten_matmul,


### PR DESCRIPTION
Implement `aten_index_select`; enable tests for transpose.

This change also added the **`trace_only`** argument to mark functions as trace only to work around functions that cannot be compiled. The logic can then be tested, but the argument should be removed later when onnxscript extends support for the syntax.