### PR TITLE
Add permute and pow ops and fix attribute value issue.

### DIFF
--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -3681,10 +3681,11 @@ def aten_pdist(self: TensorType, p: float = 2) -> TensorType:
     raise NotImplementedError()
 
 
-def aten_permute(self: TensorType, dims: Sequence[int]) -> TensorType:
+@torch_op("aten::permute")
+def aten_permute(self: TTensor, dims: Sequence[int]) -> TTensor:
     # permute(Tensor(a) self, int[] dims) -> Tensor(a)
-    # TODO(jiz): Start implementation
-    raise NotImplementedError()
+
+    return op.Transpose(self, perm=dims)
 
 
 def aten_permute_copy(self: TensorType, dims: Sequence[int]) -> TensorType:
@@ -3752,6 +3753,13 @@ def aten_positive(self: TensorType) -> TensorType:
     # positive(Tensor(a) self) -> Tensor(a)
 
     raise NotImplementedError()
+
+
+@torch_op("aten::pow")
+def aten_pow(self: TReal, exponent: TTensor) -> TReal:
+    # pow(Tensor self, Tensor exponent) -> Tensor
+
+    return op.Pow(self, exponent)
 
 
 def aten_prelu(self: TensorType, weight: TensorType) -> TensorType:

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -3683,7 +3683,7 @@ def aten_pdist(self: TensorType, p: float = 2) -> TensorType:
 
 def aten_permute(self: TensorType, dims: Sequence[int]) -> TensorType:
     # permute(Tensor(a) self, int[] dims) -> Tensor(a)
-
+    # TODO(jiz): Start implementation
     raise NotImplementedError()
 
 

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -254,7 +254,7 @@ OPINFO_FUNCTION_MAPPING: dict[
     "expand": core_ops.aten_expand,
     "erf": core_ops.aten_erf,
     "fmod": core_ops.aten_fmod,
-    # "full": (core_ops.aten_full, _full_input_wrangler),
+    "full": (core_ops.aten_full, _full_input_wrangler),
     "full_like": core_ops.aten_full_like,
     "gt": core_ops.aten_gt,
     "index_select": core_ops.aten_index_select,

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -408,6 +408,16 @@ SKIP_SUBTESTS: tuple[DecorateMeta, ...] = (
         matcher=lambda sample: "scale_factor" in sample.kwargs,
         reason="fixme: the scale_factor tests",
     ),
+    skip(
+        "permute",
+        matcher=lambda sample: len(list(filter(lambda v : v < 0, sample.args[0]))) > 0,
+        reason="Negative value in perm is not supported",
+    ),
+    skip(
+        "permute",
+        matcher=lambda sample: len(sample.args[0]) == 0,
+        reason="Empty perm is not supported",
+    ),
 )
 
 duplicate_opinfo(

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -292,6 +292,8 @@ OPINFO_FUNCTION_MAPPING: dict[
     "nonzero": core_ops.aten_nonzero,
     "ones_like": core_ops.aten_ones_like,
     "ones": core_ops.aten_ones,
+    "permute": core_ops.aten_permute,
+    "pow": core_ops.aten_pow,
     "reciprocal": core_ops.aten_reciprocal,
     "remainder": core_ops.aten_remainder,
     "repeat": core_ops.aten_repeat,

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -254,7 +254,7 @@ OPINFO_FUNCTION_MAPPING: dict[
     "expand": core_ops.aten_expand,
     "erf": core_ops.aten_erf,
     "fmod": core_ops.aten_fmod,
-    "full": (core_ops.aten_full, _full_input_wrangler),
+    # "full": (core_ops.aten_full, _full_input_wrangler),
     "full_like": core_ops.aten_full_like,
     "gt": core_ops.aten_gt,
     "index_select": core_ops.aten_index_select,

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -410,7 +410,7 @@ SKIP_SUBTESTS: tuple[DecorateMeta, ...] = (
     ),
     skip(
         "permute",
-        matcher=lambda sample: len(list(filter(lambda v : v < 0, sample.args[0]))) > 0,
+        matcher=lambda sample: len(list(filter(lambda v: v < 0, sample.args[0]))) > 0,
         reason="Negative value in perm is not supported",
     ),
     skip(

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------
 from __future__ import annotations
 
-import copy
 import dataclasses
 import logging
 import types
@@ -135,8 +134,9 @@ class Op:
         return kwargs, closure
 
     def _convert_kwargs_to_numpy(self, kwargs: dict[str, Any]) -> dict[str, Any]:
-        new_kwargs = copy.deepcopy(kwargs)
+        new_kwargs = {}
         for k, v in kwargs.items():
+            new_kwargs[k] = v
             if isinstance(v, tensor.Tensor):
                 new_kwargs[k] = v.value
 

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -133,10 +133,18 @@ class Op:
                 )
         return kwargs, closure
 
+    def _convert_kwargs_to_numpy(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        new_kwargs = {}
+        for k, v in kwargs.items():
+            if isinstance(v, tensor.Tensor):
+                new_kwargs[k] = v.value
+
+        return new_kwargs
+
     def __call__(self, *args, **kwargs):
         from onnxscript import evaluator  # pylint: disable=import-outside-toplevel
 
-        return evaluator.eval(self.opschema, args, kwargs)
+        return evaluator.eval(self.opschema, args, self._convert_kwargs_to_numpy(kwargs))
 
 
 @dataclasses.dataclass(repr=False, eq=False)

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 from __future__ import annotations
 
+import copy
 import dataclasses
 import logging
 import types
@@ -134,7 +135,7 @@ class Op:
         return kwargs, closure
 
     def _convert_kwargs_to_numpy(self, kwargs: dict[str, Any]) -> dict[str, Any]:
-        new_kwargs = {}
+        new_kwargs = copy.deepcopy(kwargs)
         for k, v in kwargs.items():
             if isinstance(v, tensor.Tensor):
                 new_kwargs[k] = v.value


### PR DESCRIPTION
1. Add 2 new ops: permute and pow.
2. Fix (partially) #287: convert the values of attributes from tensor back to numpy value when we call Op.