### PR TITLE
feat(atenlib): topk; bool argument type annotation; node of multiple outputs

### DIFF
--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -11,7 +11,7 @@
 """
 from __future__ import annotations
 
-from typing import Any, Optional, Sequence, Union, Tuple
+from typing import Any, Optional, Sequence, Tuple, Union
 
 from onnxscript import BOOL, DOUBLE, FLOAT, INT16, INT32, INT64
 from onnxscript.function_libs.torch_aten.registration import torch_op

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -4754,7 +4754,7 @@ def aten_to_sparse_csr(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-@torch_op("aten::topk", trace_only=True)
+@torch_op("aten::topk")
 def aten_topk(
     self: TReal, k: INT64, dim: int = -1, largest: bool = True, sorted: bool = True
 ) -> Tuple[TReal, INT64]:

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -4759,7 +4759,16 @@ def aten_topk(
 ) -> tuple[TensorType, TensorType]:
     # topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True) -> (Tensor values, Tensor indices)
 
-    raise NotImplementedError()
+    # TODO: Does this support dynamic k value?
+    is_scalar_input = op.Size(op.Shape(self)) == 0
+    if is_scalar_input:
+        self = op.Unsqueeze(self, op.Constant(value_ints=[0]))
+    k_value = op.Constant(value_ints=[k])
+    values, indices = op.TopK(self, k_value, axis=dim, largest=largest, sorted=sorted)
+    if is_scalar_input:
+        values = op.Squeeze(values, op.Constant(value_ints=[0]))
+        indices = op.Squeeze(indices, op.Constant(value_ints=[0]))
+    return values, indices
 
 
 def aten_trace(self: TensorType) -> TensorType:

--- a/onnxscript/test/common/testutils.py
+++ b/onnxscript/test/common/testutils.py
@@ -16,6 +16,8 @@ def function_proto(f):
         return f
     if isinstance(f, OnnxFunction):
         return f.to_function_proto()
+    if isinstance(f, str):
+        return parser.parse_function(f)
     raise TypeError(f"Cannot convert {type(f)} to FunctionProto")
 
 
@@ -51,3 +53,6 @@ class TestBase(unittest.TestCase):
 
     def assertSameGraph(self, graph1, graph2):
         self.assertTrue(isomorphic(graph_proto(graph1), graph_proto(graph2)))
+
+    def assertSameFunction(self, fn1, fn2):
+        self.assertTrue(isomorphic(function_proto(fn1), function_proto(fn2)))

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -198,10 +198,10 @@ def _logcumsumexp_input_wrangler(
     return args, kwargs
 
 
-def _topk_inputs_wrangler(
+def _topk_input_wrangler(
     args: list[Any], kwargs: dict[str, Any]
 ) -> tuple[list[Any], dict[str, Any]]:
-    # TODO: Sole purpose is to workaround attributes must be in kwargs in onnxscript.
+    # TODO(#305): Sole purpose is to workaround attributes must be in kwargs in onnxscript.
 
     if len(args) >= 3:
         kwargs["dim"] = args.pop(2)
@@ -311,7 +311,7 @@ OPINFO_FUNCTION_MAPPING: dict[
     "transpose": core_ops.aten_transpose,
     "topk": (
         core_ops.aten_topk,
-        _topk_inputs_wrangler,
+        _topk_input_wrangler,
     ),
     "unsqueeze": core_ops.aten_unsqueeze,
     "view": core_ops.aten_view,

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -198,6 +198,20 @@ def _logcumsumexp_input_wrangler(
     return args, kwargs
 
 
+def _topk_inputs_wrangler(
+    args: list[Any], kwargs: dict[str, Any]
+) -> tuple[list[Any], dict[str, Any]]:
+    # TODO: Sole purpose is to workaround attributes must be in kwargs in onnxscript.
+
+    if len(args) >= 3:
+        kwargs["dim"] = args.pop(2)
+    if len(args) >= 3:
+        kwargs["largest"] = args.pop(2)
+    if len(args) >= 3:
+        kwargs["sorted"] = args.pop(2)
+    return args, kwargs
+
+
 # Ops to be tested for numerical consistency between onnx and pytorch
 # Find the names of the OpInfos in torch/testing/_internal/common_methods_invocations.py
 OPINFO_FUNCTION_MAPPING: dict[
@@ -295,7 +309,10 @@ OPINFO_FUNCTION_MAPPING: dict[
     "tan": core_ops.aten_tan,
     "tanh": core_ops.aten_tanh,
     "transpose": core_ops.aten_transpose,
-    "topk": core_ops.aten_topk,
+    "topk": (
+        core_ops.aten_topk,
+        _topk_inputs_wrangler,
+    ),
     "unsqueeze": core_ops.aten_unsqueeze,
     "view": core_ops.aten_view,
     "where": core_ops.aten_where,

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -12,6 +12,7 @@ import onnx
 import torch
 from torch.testing._internal import common_device_type, common_methods_invocations
 from torch.testing._internal.opinfo import core as opinfo_core
+from torch.utils import _pytree as pytree
 
 import onnxscript
 from onnxscript.function_libs.torch_aten.ops import core as core_ops
@@ -294,6 +295,7 @@ OPINFO_FUNCTION_MAPPING: dict[
     "tan": core_ops.aten_tan,
     "tanh": core_ops.aten_tanh,
     "transpose": core_ops.aten_transpose,
+    "topk": core_ops.aten_topk,
     "unsqueeze": core_ops.aten_unsqueeze,
     "view": core_ops.aten_view,
     "where": core_ops.aten_where,
@@ -543,28 +545,37 @@ class TestOutputConsistency(unittest.TestCase):
                 torch_output = op(*inputs, **cpu_sample.kwargs)
                 function_output = onnx_function(*input_onnx, **kwargs_onnx)
 
-                if dtype == torch.float32:
-                    # Relax atol and rtol for float32 based on empirical results
-                    # The current most relaxed values are for aten::matmul
-                    rtol = 3.7e-6
-                    atol = 1.8e-5
-                else:
-                    rtol = None
-                    atol = None
+                # TODO: add pytree structure comparison.
+                flattened_torch_outputs, _ = pytree.tree_flatten(torch_output)
+                flattened_function_outputs, _ = pytree.tree_flatten(function_output)
 
-                if not isinstance(function_output, np.ndarray):
-                    # An onnxscript tensor
-                    function_output = function_output.value
+                assert len(flattened_torch_outputs) == len(flattened_function_outputs)
 
-                # Use torch.testing as opposed to np.testing to ensure dtypes and shapes match
-                torch.testing.assert_close(
-                    torch.tensor(function_output),
-                    torch_output
-                    if isinstance(torch_output, torch.Tensor)
-                    else torch.tensor(torch_output),
-                    rtol=rtol,
-                    atol=atol,
-                )
+                for torch_output, function_output in zip(
+                    flattened_torch_outputs, flattened_function_outputs
+                ):
+                    if dtype == torch.float32:
+                        # Relax atol and rtol for float32 based on empirical results
+                        # The current most relaxed values are for aten::matmul
+                        rtol = 3.7e-6
+                        atol = 1.8e-5
+                    else:
+                        rtol = None
+                        atol = None
+
+                    if not isinstance(function_output, np.ndarray):
+                        # An onnxscript tensor
+                        function_output = function_output.value
+
+                    # Use torch.testing as opposed to np.testing to ensure dtypes and shapes match
+                    torch.testing.assert_close(
+                        torch.tensor(function_output),
+                        torch_output
+                        if isinstance(torch_output, torch.Tensor)
+                        else torch.tensor(torch_output),
+                        rtol=rtol,
+                        atol=atol,
+                    )
 
 
 common_device_type.instantiate_device_type_tests(

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -566,6 +566,7 @@ class TestOutputConsistency(unittest.TestCase):
                 flattened_torch_outputs, _ = pytree.tree_flatten(torch_output)
                 flattened_function_outputs, _ = pytree.tree_flatten(function_output)
 
+                assert len(flattened_torch_outputs) > 0
                 assert len(flattened_torch_outputs) == len(flattened_function_outputs)
 
                 for torch_output, function_output in zip(

--- a/onnxscript/test/type_annotation_test.py
+++ b/onnxscript/test/type_annotation_test.py
@@ -5,6 +5,9 @@
 
 import unittest
 
+import onnx
+from packaging.version import Version
+
 from onnxscript import script
 from onnxscript.onnx_opset import opset15 as op
 from onnxscript.onnx_types import FLOAT
@@ -66,6 +69,10 @@ class TypeAnnotationTester(testutils.TestBase):
         with self.assertRaises(ValueError):
             FLOAT[10][20]  # Invalid usage. pylint: disable=pointless-statement
 
+    @unittest.skipIf(
+        Version(onnx.__version__) < Version("1.13"),
+        reason="module 'onnx.parser' has no attribute 'parse_function'",
+    )
     def test_type_annotation_with_bool_type_for_attribute(self):
         @script()
         def bool_type_for_attribute(self: FLOAT[...], sorted: bool) -> FLOAT[...]:

--- a/onnxscript/test/type_annotation_test.py
+++ b/onnxscript/test/type_annotation_test.py
@@ -66,6 +66,24 @@ class TypeAnnotationTester(testutils.TestBase):
         with self.assertRaises(ValueError):
             FLOAT[10][20]  # Invalid usage. pylint: disable=pointless-statement
 
+    def test_type_annotation_with_bool_type_for_attribute(self):
+        @script()
+        def bool_type_for_attribute(self: FLOAT[...], sorted: bool) -> FLOAT[...]:
+            out = op.Unique(self, sorted=sorted)
+            return out
+
+        bool_type_for_attribute_txt = """
+            <
+                domain: "this",
+                opset_import: ["": 15]
+            >
+            bool_type_for_attribute <sorted>(self) => (out) {
+                out = Unique <sorted: int = @sorted> (self)
+            }
+
+        """
+        self.assertSameFunction(bool_type_for_attribute, bool_type_for_attribute_txt)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/onnxscript/type_annotation.py
+++ b/onnxscript/type_annotation.py
@@ -17,12 +17,14 @@ _PYTYPE_TO_ATTRTYPE_MAP = {
     float: onnx.AttributeProto.FLOAT,
     int: onnx.AttributeProto.INT,
     str: onnx.AttributeProto.STRING,
+    bool: onnx.AttributeProto.INT,
 }
 
 _LISTTYPE_TO_ATTRTYPE_MAP = {
     float: onnx.AttributeProto.FLOATS,
     int: onnx.AttributeProto.INTS,
     str: onnx.AttributeProto.STRINGS,
+    bool: onnx.AttributeProto.INTS,
 }
 
 _LIST_CONSTRUCTORS = frozenset([list, typing.List, typing.Sequence, collections.abc.Sequence])


### PR DESCRIPTION
~~Concern on the annotation of `k` as `int`. I assume this would imply static value in onnx/onnxscript? Since scalars could be non-static in torch, would we want a scalar type wrapper too?~~ Answer is use `INT64`.

* Add `aten_topk`.
* Extend onnx script type annotation for bool argument for attributes.
* Extend opinfo test for multiple outputs.

Fixes #283