### PR TITLE
Fix onnxfs2_test regression for onnx 1.13

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,6 @@ steps:
     python -m pip install -r requirements-dev.txt
   displayName: 'Install dependencies'
 
-# TODO(#249): Fix tests for onnx 1.13
 - script: |
       if [ '$(onnx.standard)' == '1' ]
         then

--- a/onnxscript/test/functions/onnxfns2_test.py
+++ b/onnxscript/test/functions/onnxfns2_test.py
@@ -18,12 +18,10 @@ class TestOnnxFns(onnx_script_test_case.OnnxScriptTestCase):
         reason="onnxruntime does not support that scenario.",
     )
     def test_onnxfns_reduce_sum_square(self):
-        default_axes = None
         default_keepdims = 1
 
         self.run_onnx_test(
             onnxfns2.ReduceSumSquare,
-            axes=default_axes,
             keepdims=default_keepdims,
             # default attributes are not supported yet.
             skip_test_names=[
@@ -37,12 +35,10 @@ class TestOnnxFns(onnx_script_test_case.OnnxScriptTestCase):
         reason="onnxruntime does not support that scenario.",
     )
     def test_onnxfns_reduce_l1(self):
-        default_axes = None
         default_keepdims = 1
 
         self.run_onnx_test(
             onnxfns2.ReduceL1,
-            axes=default_axes,
             keepdims=default_keepdims,
             # default attributes are not supported yet.
             skip_test_names=[
@@ -56,12 +52,10 @@ class TestOnnxFns(onnx_script_test_case.OnnxScriptTestCase):
         reason="onnxruntime does not support that scenario.",
     )
     def test_onnxfns_reduce_l2(self):
-        default_axes = None
         default_keepdims = 1
 
         self.run_onnx_test(
             onnxfns2.ReduceL2,
-            axes=default_axes,
             keepdims=default_keepdims,
             # default attributes are not supported yet.
             skip_test_names=[
@@ -75,12 +69,10 @@ class TestOnnxFns(onnx_script_test_case.OnnxScriptTestCase):
         reason="onnxruntime does not support that scenario.",
     )
     def test_onnxfns_reduce_log_sum(self):
-        default_axes = None
         default_keepdims = 1
 
         self.run_onnx_test(
             onnxfns2.ReduceLogSum,
-            axes=default_axes,
             keepdims=default_keepdims,
             # default attributes are not supported yet.
             skip_test_names=["test_reduce_log_sum_default"],
@@ -91,12 +83,10 @@ class TestOnnxFns(onnx_script_test_case.OnnxScriptTestCase):
         reason="onnxruntime does not support that scenario.",
     )
     def test_onnxfns_reduce_log_sum_exp(self):
-        default_axes = None
         default_keepdims = 1
 
         self.run_onnx_test(
             onnxfns2.ReduceLogSumExp,
-            axes=default_axes,
             keepdims=default_keepdims,
             # default attributes are not supported yet.
             skip_test_names=[

--- a/onnxscript/test/models/onnxfns2.py
+++ b/onnxscript/test/models/onnxfns2.py
@@ -15,22 +15,18 @@ from onnxscript.onnx_types import INT64
 
 
 @script()
-def ReduceSumSquare(data, axes: List[int], keepdims: int):
-    # Note: attribute input is promoted to input when calling ReduceSum
-    t_axes = op.Constant(value_ints=axes)
-    return op.ReduceSum(data * data, t_axes, keepdims=keepdims)
+def ReduceSumSquare(data, axes, keepdims: int):
+    return op.ReduceSum(data * data, axes, keepdims=keepdims)
 
 
 @script()
-def ReduceL1(data, axes: List[int], keepdims: int):
-    t_axes = op.Constant(value_ints=axes)
-    return op.ReduceSum(op.Abs(data), t_axes, keepdims=keepdims)
+def ReduceL1(data, axes, keepdims: int):
+    return op.ReduceSum(op.Abs(data), axes, keepdims=keepdims)
 
 
 @script()
-def ReduceL2(data, axes: List[int], keepdims: int):
-    t_axes = op.Constant(value_ints=axes)
-    sum_square = op.ReduceSum(data * data, t_axes, keepdims=keepdims)
+def ReduceL2(data, axes, keepdims: int):
+    sum_square = op.ReduceSum(data * data, axes, keepdims=keepdims)
     # We need to cast integral types to floating point before taking square root.
     # Unfortunately, there is no way to do this, depending on the input type.
     # So, we uniformly cast to double, which is potentially less efficient.
@@ -40,15 +36,13 @@ def ReduceL2(data, axes: List[int], keepdims: int):
 
 
 @script()
-def ReduceLogSum(data, axes: List[int], keepdims: int):
-    t_axes = op.Constant(value_ints=axes)
-    return op.Log(op.ReduceSum(data, t_axes, keepdims=keepdims))
+def ReduceLogSum(data, axes, keepdims: int):
+    return op.Log(op.ReduceSum(data, axes, keepdims=keepdims))
 
 
 @script()
-def ReduceLogSumExp(data, axes: List[int], keepdims: int):
-    t_axes = op.Constant(value_ints=axes)
-    return op.Log(op.ReduceSum(op.Exp(data), t_axes, keepdims=keepdims))
+def ReduceLogSumExp(data, axes, keepdims: int):
+    return op.Log(op.ReduceSum(op.Exp(data), axes, keepdims=keepdims))
 
 
 @script()

--- a/requirements-onnx.txt
+++ b/requirements-onnx.txt
@@ -1,6 +1,5 @@
 # Requirements for testing with the release version of onnx and onnxruntime
 
-# TODO(#249): Fix tests for onnx 1.13
 numpy==1.22.0
-onnx==1.12
+onnx==1.13
 onnxruntime


### PR DESCRIPTION
Root cause is new "Reduce ops" spec promotes `axes` from attributes to inputs, resulting in onnx test cases having more inputs than expected by these onnx-script tests. This PR updates these onnx-script test functions to match the signature of the updated onnx test cases.

However, since onnx test cases are not versioned, I feel tests like this that seemingly want to represent ~~older opset~~ onnx operator with function should not depend on it.

Fixes #249 
Fixes #298 