### PR TITLE
test(atenlib): split mappings to two

### DIFF
--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -186,7 +186,7 @@ def aten_alpha_dropout(input: TensorType, p: float, train: bool) -> TensorType:
     raise NotImplementedError()
 
 
-# @torch_op("aten::amax")  # FIXME(#249): Uncomment when CI uses onnx 1.13
+@torch_op("aten::amax")
 def aten_amax(self: TReal, dim: INT64, keepdim: int = 0) -> TReal:
     # amax(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor
 
@@ -194,7 +194,7 @@ def aten_amax(self: TReal, dim: INT64, keepdim: int = 0) -> TReal:
     return op.ReduceMax(self, dim, keepdims=keepdim)
 
 
-# @torch_op("aten::amin")  # FIXME(#249): Uncomment when CI uses onnx 1.13
+@torch_op("aten::amin")
 def aten_amin(self: TReal, dim: INT64, keepdim: int = 0) -> TReal:
     # amin(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor
 
@@ -2704,7 +2704,7 @@ def aten_logspace(start: float, end: float, steps: int, base: float = 10.0) -> T
     raise NotImplementedError()
 
 
-@torch_op("aten::logsumexp", trace_only=True)  # FIXME(#249): Script when CI uses onnx 1.13
+@torch_op("aten::logsumexp")
 def aten_logsumexp(self: TReal, dim: INT64, keepdim: int = False) -> TReal:
     # logsumexp(Tensor self, int[1] dim, bool keepdim=False) -> Tensor
 

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -247,7 +247,6 @@ OPINFO_FUNCTION_MAPPING_SCRIPTED: dict[
     "atan": core_ops.aten_atan,
     "atanh": core_ops.aten_atanh,
     "bmm": core_ops.aten_bmm,
-    "cat": core_ops.aten_cat,
     "ceil": core_ops.aten_ceil,
     "clamp_max": core_ops.aten_clamp_max,
     "clamp_min": core_ops.aten_clamp_min,
@@ -337,6 +336,7 @@ OPINFO_FUNCTION_MAPPING_TRACE_ONLY: dict[
     str,
     Callable[..., Any] | tuple[Callable[..., Any], Callable[..., Any]],
 ] = {
+    "cat": core_ops.aten_cat,
     "index_select": core_ops.aten_index_select,
     "transpose": core_ops.aten_transpose,
 }

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -218,11 +218,7 @@ def _topk_input_wrangler(
 # Split the scripted and traced ops to make sure we don't forget to script an op
 OPINFO_FUNCTION_MAPPING_SCRIPTED: dict[
     str,
-    onnxscript.OnnxFunction
-    | tuple[
-        onnxscript.OnnxFunction,
-        Callable[[list[Any], dict[str, Any]], tuple[list[Any], dict[str, Any]]],
-    ],
+    onnxscript.OnnxFunction | tuple[onnxscript.OnnxFunction, Callable[..., Any]],
 ] = {
     "abs": core_ops.aten_abs,
     "acos": core_ops.aten_acos,
@@ -320,11 +316,7 @@ OPINFO_FUNCTION_MAPPING_SCRIPTED: dict[
 
 OPINFO_FUNCTION_MAPPING_TRACE_ONLY: dict[
     str,
-    Callable[..., Any]
-    | tuple[
-        Callable[..., Any],
-        Callable[[list[Any], dict[str, Any]], tuple[list[Any], dict[str, Any]]],
-    ],
+    Callable[..., Any] | tuple[Callable[..., Any], Callable[..., Any]],
 ] = {
     "amax": (core_ops.aten_amax, _amax_amin_input_wrangler),
     "amin": (core_ops.aten_amin, _amax_amin_input_wrangler),
@@ -341,7 +333,7 @@ OPINFO_FUNCTION_MAPPING: dict[
         onnxscript.OnnxFunction | Callable[..., Any],
         Callable[[list[Any], dict[str, Any]], tuple[list[Any], dict[str, Any]]],
     ],
-] = OPINFO_FUNCTION_MAPPING_SCRIPTED.update(OPINFO_FUNCTION_MAPPING_TRACE_ONLY)
+] = {**OPINFO_FUNCTION_MAPPING_SCRIPTED, **OPINFO_FUNCTION_MAPPING_TRACE_ONLY}
 
 TESTED_OPS = frozenset(OPINFO_FUNCTION_MAPPING)
 

--- a/onnxscript/test/onnx_backend_test.py
+++ b/onnxscript/test/onnx_backend_test.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License.
 # --------------------------------------------------------------------------
 
+# pylint: disable=too-many-boolean-expressions
+
 import importlib
 import os
 import unittest

--- a/pyproject_pylint.toml
+++ b/pyproject_pylint.toml
@@ -18,6 +18,7 @@ disable = [
   "no-name-in-module",
   "redefined-builtin",              # TODO: should we avoid redefined-builtin?
   "too-few-public-methods",
+  "too-many-arguments",
   "too-many-branches",
   "too-many-instance-attributes",
   "too-many-lines",

--- a/pyproject_pylint.toml
+++ b/pyproject_pylint.toml
@@ -18,10 +18,7 @@ disable = [
   "no-name-in-module",
   "redefined-builtin",              # TODO: should we avoid redefined-builtin?
   "too-few-public-methods",
-  "too-many-arguments",
-  "too-many-boolean-expressions",
   "too-many-branches",
-  "too-many-function-args",
   "too-many-instance-attributes",
   "too-many-lines",
   "too-many-locals",


### PR DESCRIPTION
Split the scripted and traced ops and added a test to make sure we compiled all functions.