### PR TITLE
test(atenlib): explicitly convert ints to int64

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,6 @@ coverage:
     project:
       default:
         informational: true
+    patch:
+      default:
+        informational: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -521,7 +521,7 @@ def _convert_tensor_to_numpy(input: Any) -> Any:
         return input
     if type(input) is int:  # pylint: disable=unidiomatic-typecheck
         # Take only the int type as bool is a subclass of int
-        # Explicity convert to int64 because ints are 32-bit on Windows
+        # Explicitly convert to int64 because ints are 32-bit on Windows
         return np.array(input, dtype=np.int64)
 
     return input

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -515,13 +515,14 @@ def _convert_tensor_to_numpy(input: Any) -> Any:
             return np.array((), dtype=np.int64)
         if isinstance(input[0], torch.Tensor):
             return [_convert_tensor_to_numpy(x) for x in input]
-        if isinstance(input[0], int):
+        if isinstance(input[0], (int, float)):
             # Just a tuple of numbers
-            # Explicitly convert to int64 because ints are 32-bit on Windows
-            return np.array(input, dtype=np.int64)
-        if isinstance(input[0], float):
             return np.array(input)
         return input
+    if type(input) is int:  # pylint: disable=unidiomatic-typecheck
+        # Take only the int type as bool is a subclass of int
+        # Explicity convert to int64 because ints are 32-bit on Windows
+        return np.array(input, dtype=np.int64)
 
     return input
 

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -515,8 +515,11 @@ def _convert_tensor_to_numpy(input: Any) -> Any:
             return np.array((), dtype=np.int64)
         if isinstance(input[0], torch.Tensor):
             return [_convert_tensor_to_numpy(x) for x in input]
-        if isinstance(input[0], (int, float)):
+        if isinstance(input[0], int):
             # Just a tuple of numbers
+            # Explicitly convert to int64 because ints are 32-bit on Windows
+            return np.array(input, dtype=np.int64)
+        if isinstance(input[0], float):
             return np.array(input)
         return input
 

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -174,13 +174,13 @@ def _amax_amin_input_wrangler(
 def _arange_input_wrangler(
     args: list[Any], kwargs: dict[str, Any]
 ) -> tuple[list[Any], dict[str, Any]]:
-    args = []
+    new_args = []
     for arg in args:
         if isinstance(arg, int):
             # Explicitly convert to int64 because ints are 32-bit on Windows
             arg = np.array(arg, dtype=np.int64)
-        args.append(arg)
-    return args, kwargs
+        new_args.append(arg)
+    return new_args, kwargs
 
 
 def _full_input_wrangler(

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -177,7 +177,7 @@ def _arange_input_wrangler(
     new_args = []
     for arg in args:
         if isinstance(arg, int):
-            # Explicitly convert to int64 because ints are 32-bit on Windows
+            # Explicitly convert to int64 because int type is 32-bit on Windows
             arg = np.array(arg, dtype=np.int64)
         new_args.append(arg)
     return new_args, kwargs

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -174,8 +174,12 @@ def _amax_amin_input_wrangler(
 def _arange_input_wrangler(
     args: list[Any], kwargs: dict[str, Any]
 ) -> tuple[list[Any], dict[str, Any]]:
-    # Explicitly convert to int64 because ints are 32-bit on Windows
-    args = [np.array(arg, dtype=np.int64) for arg in args]
+    args = []
+    for arg in args:
+        if isinstance(arg, int):
+            # Explicitly convert to int64 because ints are 32-bit on Windows
+            arg = np.array(arg, dtype=np.int64)
+        args.append(arg)
     return args, kwargs
 
 

--- a/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/test/function_libs/torch_aten/ops_correctness_test.py
@@ -171,6 +171,14 @@ def _amax_amin_input_wrangler(
     return args, kwargs
 
 
+def _arange_input_wrangler(
+    args: list[Any], kwargs: dict[str, Any]
+) -> tuple[list[Any], dict[str, Any]]:
+    # Explicitly convert to int64 because ints are 32-bit on Windows
+    args = [np.array(arg, dtype=np.int64) for arg in args]
+    return args, kwargs
+
+
 def _full_input_wrangler(
     args: list[Any], kwargs: dict[str, Any]
 ) -> tuple[list[Any], dict[str, Any]]:
@@ -246,9 +254,9 @@ OPINFO_FUNCTION_MAPPING_SCRIPTED: dict[
     "addmm": core_ops.aten_addmm,
     "amax": (core_ops.aten_amax, _amax_amin_input_wrangler),
     "amin": (core_ops.aten_amin, _amax_amin_input_wrangler),
-    "arange_start_step": core_ops.aten_arange_start_step,
-    "arange_start": core_ops.aten_arange_start,
-    "arange": core_ops.aten_arange,
+    "arange_start_step": (core_ops.aten_arange_start_step, _arange_input_wrangler),
+    "arange_start": (core_ops.aten_arange_start, _arange_input_wrangler),
+    "arange": (core_ops.aten_arange, _arange_input_wrangler),
     "asin": core_ops.aten_asin,
     "asinh": core_ops.aten_asinh,
     "atan": core_ops.aten_atan,
@@ -519,10 +527,6 @@ def _convert_tensor_to_numpy(input: Any) -> Any:
             # Just a tuple of numbers
             return np.array(input)
         return input
-    if type(input) is int:  # pylint: disable=unidiomatic-typecheck
-        # Take only the int type as bool is a subclass of int
-        # Explicitly convert to int64 because ints are 32-bit on Windows
-        return np.array(input, dtype=np.int64)
 
     return input
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,6 @@ classifiers = [
 ]
 dependencies = ["numpy>=1.22.0", "protobuf<4", "onnx"]
 
-[project.optional-dependencies]
-test = ["flake8", "mypy", "black", "isort[colors]", "pylint"]
-
 [tool.setuptools.dynamic]
 version = {attr = "onnxscript.__version__"}
 


### PR DESCRIPTION
This should fix #309. Green ci 1/2.

Also set codecov to be informational only so CI status is not affected