### PR TITLE
fix(ci): do not submit sarif on drafts to make reviewing easier

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - 'gh/**/base' # ghstack base branches
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   optional-lint:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,7 +6,6 @@ on:
       - main
       - 'gh/**/base' # ghstack base branches
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   optional-lint:
@@ -36,8 +35,6 @@ jobs:
   enforce-style:
     name: Enforce style
     runs-on: ubuntu-latest
-    # Do not run on drafts to make reviewing easier
-    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -72,7 +69,8 @@ jobs:
         run: |
           python -m lintrunner_adapters to-sarif lint.json lintrunner.sarif
       - name: Upload SARIF file
-        if: always()
+        # Do not display on drafts to make reviewing easier
+        if: github.event.pull_request.draft == false
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@v2
         with:


### PR DESCRIPTION
Do not submit sarif on drafts to make reviewing easier, but always run lintrunner.

Follow up of #326 