### PR TITLE
feat: generalized `Evaluator` and `Tensor` interfaces

### DIFF
--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -232,7 +232,7 @@ def _call_ort(schema, args, kwargs, implicit_args=None):
     return [_ort_to_os_value(x) for x in result]
 
 
-def schema_id(schema):
+def _schema_id(schema):
     return schema.name, schema.domain, schema.since_version
 
 
@@ -257,10 +257,10 @@ class ORTMixedEvaluator(ORTEvaluator):
         self._python_ops: dict[Any, Any] = {}
 
     def use_graph_attribute(self, schema):
-        return schema_id(schema) not in self._python_ops
+        return _schema_id(schema) not in self._python_ops
 
     def _eval(self, schema, inputs, attributes, closure):
-        schemaid = schema_id(schema)
+        schemaid = _schema_id(schema)
         if schemaid in self._python_ops:
             return self._python_ops[schemaid](inputs, attributes)
         else:
@@ -271,7 +271,7 @@ class ORTMixedEvaluator(ORTEvaluator):
 
         def decorator(function):
             schema = opset[function.__name__]
-            self._python_ops[schema_id(schema)] = function
+            self._python_ops[_schema_id(schema)] = function
             return function
 
         return decorator

--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -65,14 +65,16 @@ class Evaluator(abc.ABC):
                 )
         return closure
 
-    def adapt_outputs(self, schema, outputs):  # pylint: disable=unused-argument
+    def adapt_outputs(self, schema, outputs):
         """Adapt evaluator's output to convention used in onnxscript.
 
         Onnxscript uses a tuple/sequence only when number of outputs > 1.
         """
+        del schema  # unused
         return outputs[0] if len(outputs) == 1 else outputs
 
-    def use_graph_attribute(self, schema):  # pylint: disable=unused-argument
+    def use_graph_attribute(self, schema):
+        del schema  # unused
         return True
 
     @abc.abstractmethod

--- a/onnxscript/main.py
+++ b/onnxscript/main.py
@@ -156,7 +156,7 @@ def graph():
     # inside Sum in the above example).
 
     function_frame = sys._getframe(1)  # pylint: disable=protected-access
-    wrapper_frame = sys._getframe(2)  # pylint: disable=protected-access
+    wrapper_frame = sys._getframe(3)  # pylint: disable=protected-access
     onnx_function = wrapper_frame.f_locals["self"]
     nested_functions = onnx_function.function_ir.nested_functions
 

--- a/onnxscript/tensor.py
+++ b/onnxscript/tensor.py
@@ -31,6 +31,10 @@ class Tensor:
         return self._nparray
 
     @property
+    def rank(self):
+        return len(self._nparray.shape)
+
+    @property
     def shape(self):
         return self._nparray.shape
 

--- a/onnxscript/tensor.py
+++ b/onnxscript/tensor.py
@@ -21,7 +21,9 @@ class Tensor:
 
     def __init__(self, nparray: Optional[np.ndarray], opset=None):
         if nparray is not None and not isinstance(nparray, np.ndarray):
-            raise TypeError(f"Unexpected type {type(nparray)}. It must be a numpy array or None.")
+            raise TypeError(
+                f"Unexpected type {type(nparray)}. It must be a numpy array or None."
+            )
 
         self._nparray = nparray
         self._opset: Any = opset or onnx_opset.default_opset

--- a/onnxscript/tensor.py
+++ b/onnxscript/tensor.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Sequence
+from typing import Any, Optional
 
 import numpy as np
 from onnx import TensorProto
@@ -37,7 +37,7 @@ class Tensor:
         return len(self.value.shape)
 
     @property
-    def shape(self) -> Sequence[int]:
+    def shape(self) -> tuple[int]:
         return self.value.shape
 
     @property
@@ -46,6 +46,7 @@ class Tensor:
 
     @property
     def onnx_dtype(self) -> TensorProto.DataType:
+        # FIXME: NP_TYPE_TO_TENSOR_TYPE is deprecated
         return NP_TYPE_TO_TENSOR_TYPE[self.dtype]
 
     def __repr__(self) -> str:

--- a/onnxscript/tensor.py
+++ b/onnxscript/tensor.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional, Sequence
 
 import numpy as np
 from onnx import TensorProto
@@ -19,31 +19,33 @@ class Tensor:
     Serves to define overloaded ops with an ONNX/ONNXScript semantics.
     """
 
-    def __init__(self, nparray, opset=None):
-        if not isinstance(nparray, np.ndarray):
-            raise TypeError(f"Unexpected type {type(nparray)}. It must be a numpy array.")
-        self._nparray = nparray
+    def __init__(self, nparray: Optional[np.ndarray], opset=None):
+        if nparray is not None and not isinstance(nparray, np.ndarray):
+            raise TypeError(f"Unexpected type {type(nparray)}. It must be a numpy array or None.")
 
+        self._nparray = nparray
         self._opset: Any = opset or onnx_opset.default_opset
 
     @property
-    def value(self):
+    def value(self) -> np.ndarray:
+        if self._nparray is None:
+            raise ValueError("Tensor does not have a value.")
         return self._nparray
 
     @property
-    def rank(self):
-        return len(self._nparray.shape)
+    def rank(self) -> int:
+        return len(self.value.shape)
 
     @property
-    def shape(self):
-        return self._nparray.shape
+    def shape(self) -> Sequence[int]:
+        return self.value.shape
 
     @property
-    def dtype(self):
-        return self._nparray.dtype
+    def dtype(self) -> np.dtype:
+        return self.value.dtype
 
     @property
-    def onnx_dtype(self):
+    def onnx_dtype(self) -> TensorProto.DataType:
         return NP_TYPE_TO_TENSOR_TYPE[self.dtype]
 
     def __repr__(self) -> str:

--- a/onnxscript/tensor.py
+++ b/onnxscript/tensor.py
@@ -39,7 +39,7 @@ class Tensor:
         return len(self.value.shape)
 
     @property
-    def shape(self) -> tuple[int]:
+    def shape(self) -> tuple[int, ...]:
         return self.value.shape
 
     @property

--- a/onnxscript/test/tensor_test.py
+++ b/onnxscript/test/tensor_test.py
@@ -39,6 +39,23 @@ class TestTensor(unittest.TestCase):
         with self.assertRaises(ValueError):
             bool(x)
 
+    def test_it_can_be_initialized_with_none(self):
+        x = tensor.Tensor(None)
+        with self.assertRaises(ValueError):
+            _ = x.value
+
+    def test_rank_is_zero_for_scalar(self):
+        x = tensor.Tensor(np.array(1))
+        self.assertEqual(x.rank, 0)
+
+    def test_rank_is_one_for_vector(self):
+        x = tensor.Tensor(np.array([1, 2, 3]))
+        self.assertEqual(x.rank, 1)
+
+    def test_rank_is_two_for_matrix(self):
+        x = tensor.Tensor(np.array([[1, 2, 3], [4, 5, 6]]))
+        self.assertEqual(x.rank, 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -76,9 +76,7 @@ class Opset:
         if fun.name in self.function_defs:
 
             logger = logging.getLogger("onnx-script")
-            logger.warning(
-                "%s: Already defined.", fun.name
-            )
+            logger.warning("%s: Already defined.", fun.name)
         self.function_defs[fun.name] = fun
 
     def _prepare_inputs(self, _: onnx.defs.OpSchema, *inputs):

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -14,7 +14,7 @@ import numpy as np
 import onnx
 import onnx.defs
 
-from onnxscript import irbuilder, sourceinfo, tensor, evaluator
+from onnxscript import irbuilder, sourceinfo, tensor
 
 
 class Opset:
@@ -143,6 +143,9 @@ class Op:
         return new_kwargs
 
     def __call__(self, *args, **kwargs):
+        # FIXME(after #225): Move import to the top of the file.
+        from onnxscript import evaluator  # pylint: disable=import-outside-toplevel
+
         return evaluator.eval(self.opschema, args, self._convert_kwargs_to_numpy(kwargs))
 
 
@@ -280,6 +283,9 @@ class OnnxFunction(Op):
         """
 
         def fun(*args, **kwargs):
+            # FIXME(after #225): Move import to the top of the file.
+            from onnxscript import evaluator  # pylint: disable=import-outside-toplevel
+
             with evaluator.default_as(instance):
                 return self.__call__(*args, **kwargs)
 
@@ -287,6 +293,9 @@ class OnnxFunction(Op):
 
     def __call__(self, *args, **kwargs):
         """Implements an eager-mode execution of an onnxscript function."""
+        # FIXME(after #225): Move import to the top of the file.
+        from onnxscript import evaluator  # pylint: disable=import-outside-toplevel
+
         new_args, has_array = _adapt_to_eager_mode(args)
         result = evaluator.default().eval_function(self, *new_args, **kwargs)
 

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -288,7 +288,7 @@ class OnnxFunction(Op):
     def __call__(self, *args, **kwargs):
         """Implements an eager-mode execution of an onnxscript function."""
         new_args, has_array = _adapt_to_eager_mode(args)
-        result = evaluator.default().eval_function(self, new_args, kwargs)
+        result = evaluator.default().eval_function(self, *new_args, **kwargs)
 
         # We use a heuristic to decide whether to return output values as
         # numpy arrays or tensor.Tensors. If the function has at least one

--- a/onnxscript/values.py
+++ b/onnxscript/values.py
@@ -12,9 +12,9 @@ from typing import Any, Optional, _GenericAlias  # type: ignore[attr-defined]
 
 import numpy as np
 import onnx
-from onnx.defs import OpSchema
+import onnx.defs
 
-from onnxscript import irbuilder, sourceinfo, tensor
+from onnxscript import irbuilder, sourceinfo, tensor, evaluator
 
 
 class Opset:
@@ -76,12 +76,12 @@ class Opset:
         if fun.name in self.function_defs:
 
             logger = logging.getLogger("onnx-script")
-            logger.warning(  # pylint: disable=logging-fstring-interpolation
-                f"{fun.name}: Already defined."
+            logger.warning(
+                "%s: Already defined.", fun.name
             )
         self.function_defs[fun.name] = fun
 
-    def _prepare_inputs(self, _: OpSchema, *inputs):
+    def _prepare_inputs(self, _: onnx.defs.OpSchema, *inputs):
         """Trims 'None' values from the end of the inputs list. This is used to support
         omitting optional inputs when no more required inputs follow to prepare a valid call
         against the Op. Used by the static opset code generator.
@@ -143,8 +143,6 @@ class Op:
         return new_kwargs
 
     def __call__(self, *args, **kwargs):
-        from onnxscript import evaluator  # pylint: disable=import-outside-toplevel
-
         return evaluator.eval(self.opschema, args, self._convert_kwargs_to_numpy(kwargs))
 
 
@@ -282,8 +280,6 @@ class OnnxFunction(Op):
         """
 
         def fun(*args, **kwargs):
-            from onnxscript import evaluator  # pylint: disable=import-outside-toplevel
-
             with evaluator.default_as(instance):
                 return self.__call__(*args, **kwargs)
 
@@ -292,7 +288,7 @@ class OnnxFunction(Op):
     def __call__(self, *args, **kwargs):
         """Implements an eager-mode execution of an onnxscript function."""
         new_args, has_array = _adapt_to_eager_mode(args)
-        result = self.function(*new_args, **kwargs)
+        result = evaluator.default().eval_function(self, new_args, kwargs)
 
         # We use a heuristic to decide whether to return output values as
         # numpy arrays or tensor.Tensors. If the function has at least one


### PR DESCRIPTION
Update the evaluator and tensor's interfaces for graph capturing evaluators.

- Add `eval_function` to Evaluator and calls it from functions
- Add `rank` to `Tensor`
- Make all helper functions in evaluator private