### PR TITLE
Extend auto cast-like for attributes

### DIFF
--- a/onnxscript/converter.py
+++ b/onnxscript/converter.py
@@ -311,7 +311,7 @@ class Converter:
             result = self.generate_unique_name(target if target else "tmp")
             attr = self.to_onnx_attr_ref(val)
             self.emit([result], values.Op(self.default_opset, "Constant"), [], [attr])
-            return result
+            return ConverterExpression(result, ConverterExpressionKind.CONST)
         if isinstance(val, values.Dynamic):
             return val.value
         # Assume value is a python-value convertible to a tensor

--- a/onnxscript/test/converter_test.py
+++ b/onnxscript/test/converter_test.py
@@ -616,6 +616,17 @@ class TestConverter(testutils.TestBase):
         proto = model_script.to_model_proto()
         onnx.shape_inference.infer_shapes(proto)
 
+    def test_cast_like_attr(self):
+        @script(default_opset=op)
+        def inc_alpha(A: FLOAT[...], alpha: int) -> FLOAT[...]:
+            return A + alpha
+
+        @script()
+        def inc_alpha_expanded(A: FLOAT[...], alpha: int) -> FLOAT[...]:
+            return A + op.CastLike(alpha, A)
+
+        self.assertSame(inc_alpha, inc_alpha_expanded)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
The introduction of CastLike automatically around constants was not handling attributes promoted into constants. This PR fixes this.