### PR TITLE
fix(autocast): default int to int64

### DIFF
--- a/onnxscript/autocast.py
+++ b/onnxscript/autocast.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import Any, Callable, Optional
 
 import numpy as np

--- a/onnxscript/autocast.py
+++ b/onnxscript/autocast.py
@@ -64,16 +64,16 @@ def cast_inputs(
 def dynamic_cast_inputs(op_schema: OpSchema, *args):
     """Used for autocast during eager-mode execution."""
 
-    def get_type_info(x) -> Optional[np.dtype]:
+    def get_type_info(x):
         return x.dtype if isinstance(x, tensor.Tensor) else None
 
-    def cast(x, typeinfo: Optional[np.dtype]) -> tensor.Tensor:
+    def cast(x, typeinfo) -> tensor.Tensor:
         if isinstance(x, (bool, int, float)):
             # Scalar values are promoted to tensors of a type chosen as below:
             if typeinfo is not None:
                 dtype = typeinfo
             elif isinstance(x, bool):
-                dtype = bool
+                dtype = np.bool_
             elif isinstance(x, int):
                 dtype = np.int64
             else:

--- a/onnxscript/autocast.py
+++ b/onnxscript/autocast.py
@@ -61,10 +61,12 @@ def dynamic_cast_inputs(opschema, *args):
         return x.dtype if isinstance(x, tensor.Tensor) else None
 
     def cast(x, typeinfo):
-        if isinstance(x, (int, float)):
+        if isinstance(x, (bool, int, float)):
             # Scalar values are promoted to tensors of a type chosen as below:
             if typeinfo is not None:
                 dtype = typeinfo
+            elif isinstance(x, bool):
+                dtype = bool
             elif isinstance(x, int):
                 dtype = np.int64
             else:  # isinstance(x, float):

--- a/onnxscript/autocast.py
+++ b/onnxscript/autocast.py
@@ -66,7 +66,7 @@ def dynamic_cast_inputs(opschema, *args):
             if typeinfo is not None:
                 dtype = typeinfo
             elif isinstance(x, int):
-                dtype = np.int32
+                dtype = np.int64
             else:  # isinstance(x, float):
                 dtype = np.float32
             return tensor.Tensor(np.array(x, dtype=dtype))

--- a/onnxscript/autocast.py
+++ b/onnxscript/autocast.py
@@ -69,7 +69,8 @@ def dynamic_cast_inputs(opschema, *args):
                 dtype = bool
             elif isinstance(x, int):
                 dtype = np.int64
-            else:  # isinstance(x, float):
+            else:
+                assert isinstance(x, float)
                 dtype = np.float32
             return tensor.Tensor(np.array(x, dtype=dtype))
         return x

--- a/onnxscript/evaluator.py
+++ b/onnxscript/evaluator.py
@@ -67,8 +67,10 @@ def _adapt_to_eager_mode(inputs: ExtendedModeValue) -> tuple[EagerModeValue, boo
             return tensor.Tensor(input)
         elif isinstance(input, tensor.Tensor):
             return input
-        elif isinstance(input, (bool, int, float)):
+        elif isinstance(input, (bool, float)):
             return tensor.Tensor(np.array(input))
+        elif isinstance(input, int):
+            return tensor.Tensor(np.array(input, dtype=np.int64))
         elif input is None:
             return None
         elif isinstance(input, list):


### PR DESCRIPTION
This matches numpy and torch's behavior on linux

```
In [4]: np.array(1).dtype
Out[4]: dtype('int64')

In [6]: torch.tensor(1).dtype
Out[6]: torch.int64
```

- Also adds bool type to autocast
- Add typing information to autocast