### PR TITLE
fix(atenlib): clean up ops and fix errors

### DIFF
--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -1024,7 +1024,7 @@ def aten_conv2d(
 
     if bias is None:
         weight_dim_0 = op.Shape(weight, start=0, end=1)
-        bias_shape = op.Unsqueeze(weight_dim_0, op.Constant(value_ints=[0]))
+        bias_shape = op.Expand(weight_dim_0, op.Constant(value_ints=[1]))
         zero = op.CastLike(0.0, input)
         bias = op.Expand(zero, bias_shape)
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -59,7 +59,11 @@ def aten_add(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
 
 
 def aten_addbmm(
-    self: TensorType, batch1: TensorType, batch2: TensorType, beta: float = 1.0, alpha: float = 1.0
+    self: TensorType,
+    batch1: TensorType,
+    batch2: TensorType,
+    beta: float = 1.0,
+    alpha: float = 1.0,
 ) -> TensorType:
     # addbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
@@ -187,18 +191,18 @@ def aten_alpha_dropout(input: TensorType, p: float, train: bool) -> TensorType:
 
 
 @torch_op("aten::amax")
-def aten_amax(self: TReal, dim: INT64, keepdim: int = 0) -> TReal:
+def aten_amax(self: TReal, dim: INT64, keepdim: bool = False) -> TReal:
     # amax(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor
 
-    # TODO(justinchuby): Make dim optional, keepdim bool
+    # TODO(justinchuby): Make dim optional
     return op.ReduceMax(self, dim, keepdims=keepdim)
 
 
 @torch_op("aten::amin")
-def aten_amin(self: TReal, dim: INT64, keepdim: int = 0) -> TReal:
+def aten_amin(self: TReal, dim: INT64, keepdim: bool = False) -> TReal:
     # amin(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor
 
-    # TODO(justinchuby): Make dim optional, keepdim bool
+    # TODO(justinchuby): Make dim optional
     return op.ReduceMin(self, dim, keepdims=keepdim)
 
 
@@ -487,7 +491,11 @@ def aten_avg_pool1d(
 
 
 def aten_baddbmm(
-    self: TensorType, batch1: TensorType, batch2: TensorType, beta: float = 1.0, alpha: float = 1.0
+    self: TensorType,
+    batch1: TensorType,
+    batch2: TensorType,
+    beta: float = 1.0,
+    alpha: float = 1.0,
 ) -> TensorType:
     # baddbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -888,7 +888,7 @@ def aten_clamp(self: TReal, min: Optional[TReal] = None, max: Optional[TReal] = 
 
     # If min is greater than max torch.clamp(..., min, max)
     # sets all elements in input to the value of max.
-
+    # So this order is important.
     if min is not None:
         min_clamp = op.CastLike(min, self)
         clamped = op.Max(clamped, min_clamp)

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -2049,10 +2049,9 @@ def aten_from_file(
 def aten_full(size: INT64, fill_value: float, dtype: int = FLOAT.dtype):
     # full(SymInt[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
-    fill_value = op.Cast(fill_value, to=dtype)
     size = op.Cast(size, to=INT64.dtype)
-    result = op.Expand(fill_value, size)
-    return result
+    fill_value = op.Cast(fill_value, to=dtype)
+    return = op.Expand(fill_value, size)
 
 
 @torch_op("aten::full_like")

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -51,7 +51,7 @@ def aten_acosh(self: TFloat) -> TFloat:
 
 
 @torch_op("aten::add")
-def aten_add(self: TReal, other: TReal, alpha: float = 1) -> TReal:
+def aten_add(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
     # add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
     alpha = op.CastLike(alpha, other)
     other = op.Mul(other, alpha)
@@ -59,7 +59,7 @@ def aten_add(self: TReal, other: TReal, alpha: float = 1) -> TReal:
 
 
 def aten_addbmm(
-    self: TensorType, batch1: TensorType, batch2: TensorType, beta: float = 1, alpha: float = 1
+    self: TensorType, batch1: TensorType, batch2: TensorType, beta: float = 1.0, alpha: float = 1.0
 ) -> TensorType:
     # addbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
@@ -67,7 +67,7 @@ def aten_addbmm(
 
 
 def aten_addcdiv(
-    self: TensorType, tensor1: TensorType, tensor2: TensorType, value: float = 1
+    self: TensorType, tensor1: TensorType, tensor2: TensorType, value: float = 1.0
 ) -> TensorType:
     # addcdiv(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
 
@@ -75,7 +75,7 @@ def aten_addcdiv(
 
 
 def aten_addcmul(
-    self: TensorType, tensor1: TensorType, tensor2: TensorType, value: float = 1
+    self: TensorType, tensor1: TensorType, tensor2: TensorType, value: float = 1.0
 ) -> TensorType:
     # addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
 
@@ -84,7 +84,7 @@ def aten_addcmul(
 
 @torch_op("aten::addmm")
 def aten_addmm(
-    self: TFloat, mat1: TFloat, mat2: TFloat, beta: float = 1, alpha: float = 1
+    self: TFloat, mat1: TFloat, mat2: TFloat, beta: float = 1.0, alpha: float = 1.0
 ) -> TFloat:
     # addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
@@ -95,7 +95,7 @@ def aten_addmm(
 
 
 def aten_addmv(
-    self: TensorType, mat: TensorType, vec: TensorType, beta: float = 1, alpha: float = 1
+    self: TensorType, mat: TensorType, vec: TensorType, beta: float = 1.0, alpha: float = 1.0
 ) -> TensorType:
     # addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
@@ -103,7 +103,7 @@ def aten_addmv(
 
 
 def aten_addr(
-    self: TensorType, vec1: TensorType, vec2: TensorType, beta: float = 1, alpha: float = 1
+    self: TensorType, vec1: TensorType, vec2: TensorType, beta: float = 1.0, alpha: float = 1.0
 ) -> TensorType:
     # addr(Tensor self, Tensor vec1, Tensor vec2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
@@ -487,7 +487,7 @@ def aten_avg_pool1d(
 
 
 def aten_baddbmm(
-    self: TensorType, batch1: TensorType, batch2: TensorType, beta: float = 1, alpha: float = 1
+    self: TensorType, batch1: TensorType, batch2: TensorType, beta: float = 1.0, alpha: float = 1.0
 ) -> TensorType:
     # baddbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
@@ -769,7 +769,7 @@ def aten_ccol_indices_copy(self: TensorType) -> TensorType:
 
 
 def aten_cdist(
-    x1: TensorType, x2: TensorType, p: float = 2, compute_mode: Optional[int] = None
+    x1: TensorType, x2: TensorType, p: float = 2.0, compute_mode: Optional[int] = None
 ) -> TensorType:
     # cdist(Tensor x1, Tensor x2, float p=2, int? compute_mode=None) -> Tensor
 
@@ -971,7 +971,7 @@ def aten_conj_physical(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-def aten_constant_pad_nd(self: TensorType, pad: INT64, value: float = 0) -> TensorType:
+def aten_constant_pad_nd(self: TensorType, pad: INT64, value: float = 0.0) -> TensorType:
     # constant_pad_nd(Tensor self, SymInt[] pad, Scalar value=0) -> Tensor
 
     raise NotImplementedError()
@@ -1551,7 +1551,7 @@ def aten_digamma(self: TensorType) -> TensorType:
     raise NotImplementedError()
 
 
-def aten_dist(self: TensorType, other: TensorType, p: float = 2) -> TensorType:
+def aten_dist(self: TensorType, other: TensorType, p: float = 2.0) -> TensorType:
     # dist(Tensor self, Tensor other, Scalar p=2) -> Tensor
 
     raise NotImplementedError()
@@ -2237,7 +2237,7 @@ def aten_hinge_embedding_loss(
 
 
 def aten_histc(
-    self: TensorType, bins: int = 100, min: float = 0, max: float = 0
+    self: TensorType, bins: int = 100, min: float = 0.0, max: float = 0.0
 ) -> TensorType:
     # histc(Tensor self, int bins=100, Scalar min=0, Scalar max=0) -> Tensor
 
@@ -3648,7 +3648,7 @@ def aten_native_layer_norm_backward(
     raise NotImplementedError()
 
 
-def aten_native_norm(self: TensorType, p: float = 2) -> TensorType:
+def aten_native_norm(self: TensorType, p: float = 2.0) -> TensorType:
     # native_norm(Tensor self, Scalar p=2) -> Tensor
 
     raise NotImplementedError()
@@ -3736,7 +3736,7 @@ def aten_norm_except_dim(v: TensorType, pow: int = 2, dim: int = 0) -> TensorTyp
 
 
 def aten_normal(
-    self: TensorType, mean: float = 0, std: float = 1, generator: Optional[str] = None
+    self: TensorType, mean: float = 0.0, std: float = 1.0, generator: Optional[str] = None
 ) -> TensorType:
     # normal_functional(Tensor self, float mean=0, float std=1, *, Generator? generator=None) -> Tensor
 
@@ -3819,14 +3819,14 @@ def aten_output_nr(self: TensorType) -> int:
 
 
 def aten_pairwise_distance(
-    x1: TensorType, x2: TensorType, p: float = 2, eps: float = 1e-06, keepdim: bool = False
+    x1: TensorType, x2: TensorType, p: float = 2.0, eps: float = 1e-06, keepdim: bool = False
 ) -> TensorType:
     # pairwise_distance(Tensor x1, Tensor x2, float p=2, float eps=1e-06, bool keepdim=False) -> Tensor
 
     raise NotImplementedError()
 
 
-def aten_pdist(self: TensorType, p: float = 2) -> TensorType:
+def aten_pdist(self: TensorType, p: float = 2.0) -> TensorType:
     # pdist(Tensor self, float p=2) -> Tensor
 
     raise NotImplementedError()
@@ -4693,7 +4693,7 @@ def aten_squeeze_copy(self: TensorType) -> TensorType:
 
 
 def aten_sspaddmm(
-    self: TensorType, mat1: TensorType, mat2: TensorType, beta: float = 1, alpha: float = 1
+    self: TensorType, mat1: TensorType, mat2: TensorType, beta: float = 1.0, alpha: float = 1.0
 ) -> TensorType:
     # sspaddmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 
@@ -4734,7 +4734,7 @@ def aten_stft(
 
 
 @torch_op("aten::sub")
-def aten_sub(self: TReal, other: TReal, alpha: float = 1) -> TReal:
+def aten_sub(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
     # sub.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
 
     if alpha != 1:
@@ -4743,7 +4743,7 @@ def aten_sub(self: TReal, other: TReal, alpha: float = 1) -> TReal:
     return op.Sub(self, other)
 
 
-def aten_subtract(self: TensorType, other: TensorType, alpha: float = 1) -> TensorType:
+def aten_subtract(self: TensorType, other: TensorType, alpha: float = 1.0) -> TensorType:
     # subtract.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
 
     raise NotImplementedError()
@@ -5052,7 +5052,7 @@ def aten_triplet_margin_loss(
     positive: TensorType,
     negative: TensorType,
     margin: float = 1.0,
-    p: float = 2,
+    p: float = 2.0,
     eps: float = 1e-06,
     swap: bool = False,
     reduction: int = 1,

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -2046,13 +2046,17 @@ def aten_from_file(
 
 
 @torch_op("aten::full")
-def aten_full(size: INT64, fill_value: TensorType, dtype: int = FLOAT.dtype):
+def aten_full(size: INT64, fill_value: float, dtype: int = -1):
     # full(SymInt[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
     size = op.Cast(size, to=INT64.dtype)
-    fill_value = op.Cast(fill_value, to=dtype)
+    if dtype == -1:
+        result = op.ConstantOfShape(size, value=fill_value)
+    else:
+        result = op.ConstantOfShape(size, value=fill_value)
+        result = op.Cast(result, to=dtype)
 
-    return op.Expand(fill_value, size)
+    return result
 
 
 @torch_op("aten::full_like")

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -53,8 +53,8 @@ def aten_acosh(self: TFloat) -> TFloat:
 @torch_op("aten::add")
 def aten_add(self: TReal, other: TReal, alpha: float = 1) -> TReal:
     # add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
-    if alpha != 1:
-        other = op.Mul(other, alpha)
+    alpha = op.CastLike(alpha, other)
+    other = op.Mul(other, alpha)
     return op.Add(self, other)
 
 
@@ -1023,8 +1023,8 @@ def aten_conv2d(
     strides = list(stride)
 
     if bias is None:
-        weight_dim_0 = op.Gather(op.Shape(weight), 0, axis=0)
-        bias_shape = op.Expand(weight_dim_0, op.Constant(value_ints=[1]))
+        weight_dim_0 = op.Shape(weight, start=0, end=1)
+        bias_shape = op.Unsqueeze(weight_dim_0, op.Constant(value_ints=[0]))
         zero = op.CastLike(0.0, input)
         bias = op.Expand(zero, bias_shape)
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -4796,9 +4796,8 @@ def aten_stft(
 @torch_op("aten::sub")
 def aten_sub(self: TReal, other: TReal, alpha: float = 1.0) -> TReal:
     # sub.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
-
-    if alpha != 1:
-        other = op.Mul(other, alpha)
+    alpha = op.CastLike(alpha, other)
+    other = op.Mul(other, alpha)
 
     return op.Sub(self, other)
 
@@ -5334,9 +5333,8 @@ def aten_vstack(tensors: Sequence[TensorType]) -> TensorType:
 
 
 @torch_op("aten::where")
-def aten_where(self: TTensor, condition: RealType, other: TTensor) -> TTensor:
+def aten_where(condition: BOOL, self: TTensor, other: TTensor) -> TTensor:
     # where.self(Tensor condition, Tensor self, Tensor other) -> Tensor
-    condition = op.Cast(condition, to=BOOL.dtype)
 
     return op.Where(condition, self, other)
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -886,13 +886,16 @@ def aten_clamp(self: TReal, min: Optional[TReal] = None, max: Optional[TReal] = 
     if min is None and max is None:
         return clamped
 
-    if max is not None:
-        max_clamp = op.CastLike(max, self)
-        clamped = op.Min(clamped, max_clamp)
+    # If min is greater than max torch.clamp(..., min, max)
+    # sets all elements in input to the value of max.
 
     if min is not None:
         min_clamp = op.CastLike(min, self)
         clamped = op.Max(clamped, min_clamp)
+
+    if max is not None:
+        max_clamp = op.CastLike(max, self)
+        clamped = op.Min(clamped, max_clamp)
 
     return clamped
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -2049,13 +2049,11 @@ def aten_from_file(
 def aten_full(size: INT64, fill_value: float, dtype: int = -1):
     # full(SymInt[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
-    size = op.Cast(size, to=INT64.dtype)
-    if dtype == -1:
-        result = op.ConstantOfShape(size, value=fill_value)
-    else:
-        result = op.ConstantOfShape(size, value=fill_value)
-        result = op.Cast(result, to=dtype)
+    if dtype != -1:
+        fill_value = op.Cast(fill_value, to=dtype)
 
+    size = op.Cast(size, to=INT64.dtype)
+    result = op.Expand(fill_value, size)
     return result
 
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -3647,7 +3647,7 @@ def aten_native_layer_norm(
     axes = [-i for i in range(len(normalized_shape), 0, -1)]
     if weight is None:
         weight = op.CastLike(1, input)
-    if bias is not None:
+    if bias is None:
         bias = op.CastLike(0, input)
     return _aten_native_layer_norm_onnx(input, weight, bias, axes=axes, eps=eps)
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -17,6 +17,7 @@ from onnxscript import BOOL, DOUBLE, FLOAT, INT16, INT32, INT64
 from onnxscript.function_libs.torch_aten.registration import torch_op
 from onnxscript.function_libs.torch_aten.tensor_typing import (
     IntType,
+    RealType,
     TFloat,
     TFloatOrBFloat16,
     TInt,
@@ -5329,8 +5330,9 @@ def aten_vstack(tensors: Sequence[TensorType]) -> TensorType:
 
 
 @torch_op("aten::where")
-def aten_where(self: TTensor, condition: BOOL, other: TTensor) -> TTensor:
+def aten_where(self: TTensor, condition: RealType, other: TTensor) -> TTensor:
     # where.self(Tensor condition, Tensor self, Tensor other) -> Tensor
+    condition = op.Cast(condition, to=BOOL.dtype)
 
     return op.Where(condition, self, other)
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -17,7 +17,6 @@ from onnxscript import BOOL, DOUBLE, FLOAT, INT16, INT32, INT64
 from onnxscript.function_libs.torch_aten.registration import torch_op
 from onnxscript.function_libs.torch_aten.tensor_typing import (
     IntType,
-    RealType,
     TFloat,
     TFloatOrBFloat16,
     TInt,

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -198,7 +198,22 @@ def aten_amax(self: TReal, dim: Optional[int] = None, keepdim: bool = False) -> 
     # TODO(justinchuby): Make dim INT64 after we upgrade to onnxruntime 1.14
     if dim is None:
         return opset17.ReduceMax(self, keepdims=keepdim)
-    return opset17.ReduceMax(self, axes=[dim], keepdims=keepdim)
+    if not isinstance(dim, Sequence):
+        dims = [dim]
+    else:
+        dims = list(dim)
+    return _aten_amax_onnx(self, axes=dims, keepdims=keepdim)
+
+
+@torch_op("aten::amax", overload=True)
+def _aten_amax_onnx(self: TReal, axes: Sequence[int], keepdims: bool) -> TReal:
+    # TODO(justinchuby): Use opset18 after we upgrade to onnxruntime 1.14
+    if opset17.Size(opset17.Shape(self)) == 0:
+        # Scalar
+        result = self
+    else:
+        result = opset17.ReduceMax(self, axes=axes, keepdims=keepdims)
+    return result
 
 
 @torch_op("aten::amin", trace_only=True)
@@ -208,7 +223,22 @@ def aten_amin(self: TReal, dim: Optional[int] = None, keepdim: bool = False) -> 
     # TODO(justinchuby): Make dim INT64 after we upgrade to onnxruntime 1.14
     if dim is None:
         return opset17.ReduceMin(self, keepdims=keepdim)
-    return opset17.ReduceMin(self, axes=[dim], keepdims=keepdim)
+    if not isinstance(dim, Sequence):
+        dims = [dim]
+    else:
+        dims = list(dim)
+    return _aten_amin_onnx(self, axes=dims, keepdims=keepdim)
+
+
+@torch_op("aten::amin", overload=True)
+def _aten_amin_onnx(self: TReal, axes: Sequence[int], keepdims: bool) -> TReal:
+    # TODO(justinchuby): Use opset18 after we upgrade to onnxruntime 1.14
+    if opset17.Size(opset17.Shape(self)) == 0:
+        # Scalar
+        result = self
+    else:
+        result = opset17.ReduceMin(self, axes=axes, keepdims=keepdims)
+    return result
 
 
 def aten_aminmax(

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -2046,12 +2046,10 @@ def aten_from_file(
 
 
 @torch_op("aten::full")
-def aten_full(size: INT64, fill_value: float, dtype: int = -1):
+def aten_full(size: INT64, fill_value: float, dtype: int = FLOAT.dtype):
     # full(SymInt[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
-    if dtype != -1:
-        fill_value = op.Cast(fill_value, to=dtype)
-
+    fill_value = op.Cast(fill_value, to=dtype)
     size = op.Cast(size, to=INT64.dtype)
     result = op.Expand(fill_value, size)
     return result

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -2051,7 +2051,7 @@ def aten_full(size: INT64, fill_value: float, dtype: int = FLOAT.dtype):
 
     size = op.Cast(size, to=INT64.dtype)
     fill_value = op.Cast(fill_value, to=dtype)
-    return = op.Expand(fill_value, size)
+    return op.Expand(fill_value, size)
 
 
 @torch_op("aten::full_like")

--- a/onnxscript/function_libs/torch_aten/ops/nn.py
+++ b/onnxscript/function_libs/torch_aten/ops/nn.py
@@ -494,7 +494,8 @@ def aten_linear(input: TFloat, weight: TFloat, bias: Optional[TFloat] = None) ->
 
     # NOTE: The symbolic function in torch.onnx also uses Gemm in certain cases
     # Optimizers may consider this path and replace it with Gemm
-    result = op.MatMul(input, weight)
+    weight_transposed = op.Transpose(weight, perm=[1, 0])
+    result = op.MatMul(input, weight_transposed)
     if bias is not None:
         result = op.Add(result, bias)
     return result

--- a/onnxscript/function_libs/torch_aten/ops/nn.py
+++ b/onnxscript/function_libs/torch_aten/ops/nn.py
@@ -417,7 +417,7 @@ def aten_hardswish_backward(grad_output: TensorType, self: TensorType) -> Tensor
     raise NotImplementedError()
 
 
-def aten_hardtanh(self: TensorType, min_val: float = -1, max_val: float = 1) -> TensorType:
+def aten_hardtanh(self: TensorType, min_val: float = -1.0, max_val: float = 1.0) -> TensorType:
     # hardtanh(Tensor self, Scalar min_val=-1, Scalar max_val=1) -> Tensor
 
     raise NotImplementedError()
@@ -488,20 +488,14 @@ def aten_leaky_relu_backward(
     raise NotImplementedError()
 
 
-@torch_op("aten::linear")
+@torch_op("aten::linear", trace_only=True)
 def aten_linear(input: TFloat, weight: TFloat, bias: Optional[TFloat] = None) -> TFloat:
     # linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor
-
-    # FIXME(justinchuby): Enable the test
-    # INVALID_GRAPH : This is an invalid model.
-    # In Node, ("", OptionalHasElement, "", -1) : () -> ("output0",) ,
-    # Error Node () has input size 0 not in range [min=1, max=1]
 
     # NOTE: The symbolic function in torch.onnx also uses Gemm in certain cases
     # Optimizers may consider this path and replace it with Gemm
     result = op.MatMul(input, weight)
-    if op.OptionalHasElement(bias):
-        bias = op.OptionalGetElement(bias)
+    if bias is not None:
         result = op.Add(result, bias)
     return result
 
@@ -672,8 +666,8 @@ def aten_mse_loss_backward(
 def aten_multi_margin_loss(
     self: TensorType,
     target: TensorType,
-    p: float = 1,
-    margin: float = 1,
+    p: float = 1.0,
+    margin: float = 1.0,
     weight: Optional[TensorType] = None,
     reduction: int = 1,
 ) -> TensorType:
@@ -1094,7 +1088,7 @@ def aten_soft_margin_loss_backward(
     raise NotImplementedError()
 
 
-def aten_softplus(self: TensorType, beta: float = 1, threshold: float = 20) -> TensorType:
+def aten_softplus(self: TensorType, beta: float = 1.0, threshold: float = 20.0) -> TensorType:
     # softplus(Tensor self, Scalar beta=1, Scalar threshold=20) -> Tensor
 
     raise NotImplementedError()

--- a/onnxscript/function_libs/torch_aten/ops/sparse.py
+++ b/onnxscript/function_libs/torch_aten/ops/sparse.py
@@ -15,7 +15,7 @@ from onnxscript.onnx_types import TensorType
 
 
 def aten_sparse_sampled_addmm(
-    self: TensorType, mat1: TensorType, mat2: TensorType, beta: float = 1, alpha: float = 1
+    self: TensorType, mat1: TensorType, mat2: TensorType, beta: float = 1.0, alpha: float = 1.0
 ) -> TensorType:
     # sparse_sampled_addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
 

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -281,8 +281,6 @@ OPINFO_FUNCTION_MAPPING_SCRIPTED: dict[
     "acosh": core_ops.aten_acosh,
     "add": core_ops.aten_add,
     "addmm": core_ops.aten_addmm,
-    "amax": (core_ops.aten_amax, _amax_amin_input_wrangler),
-    "amin": (core_ops.aten_amin, _amax_amin_input_wrangler),
     "arange_start_step": core_ops.aten_arange_start_step,
     "arange_start": core_ops.aten_arange_start,
     "arange": core_ops.aten_arange,
@@ -393,6 +391,8 @@ OPINFO_FUNCTION_MAPPING_TRACE_ONLY: dict[
     str,
     Callable[..., Any] | tuple[Callable[..., Any], Callable[..., Any]],
 ] = {
+    "amax": (core_ops.aten_amax, _amax_amin_input_wrangler),
+    "amin": (core_ops.aten_amin, _amax_amin_input_wrangler),
     "argmax": core_ops.aten_argmax,
     "argmin": core_ops.aten_argmin,
     "clamp": core_ops.aten_clamp,

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -296,7 +296,6 @@ OPINFO_FUNCTION_MAPPING_SCRIPTED: dict[
     "ceil": core_ops.aten_ceil,
     "clamp_max": core_ops.aten_clamp_max,
     "clamp_min": core_ops.aten_clamp_min,
-    "clamp": core_ops.aten_clamp,
     "clone": core_ops.aten_clone,
     "cos": core_ops.aten_cos,
     "cosh": core_ops.aten_cosh,
@@ -396,6 +395,7 @@ OPINFO_FUNCTION_MAPPING_TRACE_ONLY: dict[
 ] = {
     "argmax": core_ops.aten_argmax,
     "argmin": core_ops.aten_argmin,
+    "clamp": core_ops.aten_clamp,
     "index_select": core_ops.aten_index_select,
     "native_layer_norm": core_ops.aten_native_layer_norm,
     "nn.functional.conv2d": core_ops.aten_conv2d,
@@ -417,14 +417,10 @@ OPINFO_FUNCTION_MAPPING: dict[
 TESTED_OPS = frozenset(OPINFO_FUNCTION_MAPPING)
 
 EXPECTED_SKIPS_OR_FAILS = (
-    xfail("amax", reason="ONNX Runtime 1.13 does not support ReduceMax-18"),
-    xfail("amin", reason="ONNX Runtime 1.13 does not support ReduceMin-18"),
-    xfail("clamp", reason="Enable when ONNX Runtime supports OptionalHasElement-18"),
     skip("empty", reason="Using zeros to simulate empty"),
     skip("empty_like", reason="Using zeros_like to simulate empty_like"),
     xfail("logcumsumexp", reason="naive implementation not numerically stable"),
     xfail("logsumexp", reason="ONNX Runtime 1.13 does not support ReduceLogSumExp-18"),
-    xfail("native_layer_norm", reason="ONNX Runtime 1.13 does not support ReduceMean-18"),
     xfail(
         "nn.functional.upsample_nearest2d",
         reason="enable when ONNX Runtime does support opset18",

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -170,14 +170,6 @@ OPS_DB = copy.deepcopy(common_methods_invocations.op_db)
 # Modify this section ##########################################################
 
 
-def _amax_amin_input_wrangler(
-    args: list[Any], kwargs: dict[str, Any]
-) -> tuple[list[Any], dict[str, Any]]:
-    if "dim" not in kwargs:
-        kwargs["dim"] = None
-    return args, kwargs
-
-
 def _cat_input_wrangler(
     args: list[Any], kwargs: dict[str, Any]
 ) -> tuple[list[Any], dict[str, Any]]:
@@ -391,8 +383,8 @@ OPINFO_FUNCTION_MAPPING_TRACE_ONLY: dict[
     str,
     Callable[..., Any] | tuple[Callable[..., Any], Callable[..., Any]],
 ] = {
-    "amax": (core_ops.aten_amax, _amax_amin_input_wrangler),
-    "amin": (core_ops.aten_amin, _amax_amin_input_wrangler),
+    "amax": core_ops.aten_amax,
+    "amin": core_ops.aten_amin,
     "argmax": core_ops.aten_argmax,
     "argmin": core_ops.aten_argmin,
     "clamp": core_ops.aten_clamp,

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -255,6 +255,15 @@ def _topk_input_wrangler(
     return args, kwargs
 
 
+def _where_input_wrangler(
+    args: list[Any], kwargs: dict[str, Any]
+) -> tuple[list[Any], dict[str, Any]]:
+    # The aten::where op takes condition, x, y as inputs
+    # Swap the first two inputs
+    args[0], args[1] = args[1], args[0]
+    return args, kwargs
+
+
 # Ops to be tested for numerical consistency between onnx and pytorch
 # Find the names of the OpInfos in torch/testing/_internal/common_methods_invocations.py
 
@@ -371,7 +380,7 @@ OPINFO_FUNCTION_MAPPING_SCRIPTED: dict[
     ),
     "unsqueeze": core_ops.aten_unsqueeze,
     "view": core_ops.aten_view,
-    "where": core_ops.aten_where,
+    "where": (core_ops.aten_where, _where_input_wrangler),
     "xlogy": special_ops.aten_special_xlogy,
     "zeros": core_ops.aten_zeros,
     "zeros_like": core_ops.aten_zeros_like,

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -345,7 +345,6 @@ OPINFO_FUNCTION_MAPPING_SCRIPTED: dict[
     "nn.functional.embedding": core_ops.aten_embedding,
     "nn.functional.gelu": nn_ops.aten_gelu,
     "nn.functional.leaky_relu": nn_ops.aten_leaky_relu,
-    "nn.functional.linear": nn_ops.aten_linear,
     "nn.functional.logsigmoid": nn_ops.aten_log_sigmoid,
     "nn.functional.relu": nn_ops.aten_relu,
     "nn.functional.relu6": nn_ops.aten_relu6,
@@ -400,6 +399,7 @@ OPINFO_FUNCTION_MAPPING_TRACE_ONLY: dict[
     "index_select": core_ops.aten_index_select,
     "native_layer_norm": core_ops.aten_native_layer_norm,
     "nn.functional.conv2d": core_ops.aten_conv2d,
+    "nn.functional.linear": nn_ops.aten_linear,
     "sum": (core_ops.aten_sum_dim_IntList, _sum_input_wrangler),
     "transpose": core_ops.aten_transpose,
 }
@@ -424,11 +424,7 @@ EXPECTED_SKIPS_OR_FAILS = (
     skip("empty_like", reason="Using zeros_like to simulate empty_like"),
     xfail("logcumsumexp", reason="naive implementation not numerically stable"),
     xfail("logsumexp", reason="ONNX Runtime 1.13 does not support ReduceLogSumExp-18"),
-    xfail("native_layer_norm", reason="ONNX Runtime 1.13 does not support ReduceMean"),
-    xfail(
-        "nn.functional.linear",
-        reason="ONNX Runtime thinks the graph is invalid",
-    ),
+    xfail("native_layer_norm", reason="ONNX Runtime 1.13 does not support ReduceMean-18"),
     xfail(
         "nn.functional.upsample_nearest2d",
         reason="enable when ONNX Runtime does support opset18",

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -358,7 +358,6 @@ OPINFO_FUNCTION_MAPPING_SCRIPTED: dict[
     "sign": core_ops.aten_sign,
     "sin": core_ops.aten_sin,
     "sinh": core_ops.aten_sinh,
-    "slice": core_ops.aten_slice,
     "softmax": (special_ops.aten_special_softmax, _softmax_input_wrangler),
     "split": (core_ops.aten_split, _split_input_wrangler),
     "sqrt": core_ops.aten_sqrt,
@@ -392,6 +391,7 @@ OPINFO_FUNCTION_MAPPING_TRACE_ONLY: dict[
     "native_layer_norm": core_ops.aten_native_layer_norm,
     "nn.functional.conv2d": core_ops.aten_conv2d,
     "nn.functional.linear": nn_ops.aten_linear,
+    "slice": core_ops.aten_slice,
     "sum": (core_ops.aten_sum_dim_IntList, _sum_input_wrangler),
     "transpose": core_ops.aten_transpose,
 }
@@ -505,12 +505,6 @@ SKIP_SUBTESTS: tuple[DecorateMeta, ...] = (
         "permute",
         matcher=lambda sample: len(sample.args[0]) == 0,
         reason="Empty perm is not supported",
-    ),
-    skip(
-        "slice",
-        # kwargs {dim, start, end, step} is empty, we cannot give the default value
-        matcher=lambda sample: len(sample.kwargs) == 0,
-        reason="start and end must be 1-D array, cannot be optional, due to ort 1.13 does not support yet",
     ),
 )
 


### PR DESCRIPTION
- Simplify logic in `add`, `conv2d`.
- Update all float attribute defaults to actual floating-point numbers instead of ints. 
- Fix `linear` logic (transpose weight) and enable tests
- Fix clamp
- Fix amin amax
- Fix native_layer_norm
- Fix slice
- Fix where signature
- Fix full
- Fix sub

Ops that uses ReduceMin and ReduceMax are currently on opset17, as onnxruntime does not support them and we want to use ort to run fx tests.