### PR TITLE
integrate with fake_gpt.py

### DIFF
--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -306,7 +306,7 @@ class TorchScriptGraph:
 
     @beartype
     def add_input(
-        self, input_name: str, input_value: Union[torch.Tensor, None]
+        self, input_name: str, input_value: Optional[torch.Tensor] = None
     ) -> TorchScriptTensor:
         # TODO: Take in a TorchScriptTensor?
         # TODO: Support dynamic shapes

--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -305,7 +305,9 @@ class TorchScriptGraph:
         return self._torch_graph
 
     @beartype
-    def add_input(self, input_name: str, input_value: torch.Tensor) -> TorchScriptTensor:
+    def add_input(
+        self, input_name: str, input_value: Union[torch.Tensor, None]
+    ) -> TorchScriptTensor:
         # TODO: Take in a TorchScriptTensor?
         # TODO: Support dynamic shapes
         if input_value is None:


### PR DESCRIPTION
[fake_gpt.py](https://github.com/pytorch/pytorch/blob/onnx-team/dynamo-exporter/torch/onnx/_internal/docs/fake_gpt.py) might add None as input for graph builder. Further looking into it, it seems just a bug, as we already defined a if branch for None value.