### PR TITLE
feat(atenlib): enable model checker in TorchScriptGraph

### DIFF
--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -348,6 +348,14 @@ class TorchScriptGraph:
         return
 
     def _add_constant_to_graph(self, constant) -> torch.Value:
+        if isinstance(constant, bool):
+            # Be sure to put bool before int, because bool is a subclass of int
+            return _create_op_call_in_torch_graph(
+                self._torch_graph,
+                "onnx::Constant",
+                inputs=(),
+                attributes=dict(value=torch.tensor(constant, dtype=torch.bool)),
+            )[0]
         if isinstance(constant, float):
             return _create_op_call_in_torch_graph(
                 self._torch_graph,

--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import typing
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 import warnings
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import onnx

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -1124,6 +1124,7 @@ def aten_conv2d(
         input,
         weight,
         bias,
+        transposed=False,
         strides=strides,
         pads=pads,
         dilations=dilations,
@@ -1234,8 +1235,8 @@ def _aten_convolution_onnx(
     strides: Sequence[int],
     pads: Sequence[int],
     dilations: Sequence[int],
-    output_padding: Sequence[int],
-    groups: int,
+    output_padding: Sequence[int] = [0],
+    groups: int = 1,
 ) -> TFloat:
     """ConvXd with attributes pre-computed to fit the ONNX spec."""
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -1214,10 +1214,10 @@ def aten_convolution(
         input,
         weight,
         bias,
+        transposed,
         strides=strides,
         pads=pads,
         dilations=dilations,
-        transposed=transposed,
         output_padding=output_padding,
         groups=groups,
     )
@@ -1230,14 +1230,19 @@ def _aten_convolution_onnx(
     input: TFloat,
     weight: TFloat,
     bias: TFloat,
+    transposed: BOOL,
     strides: Sequence[int],
     pads: Sequence[int],
     dilations: Sequence[int],
-    transposed: bool = False,
-    output_padding: Sequence[int] = (0,),
-    groups: int = 1,
+    output_padding: Sequence[int],
+    groups: int,
 ) -> TFloat:
     """ConvXd with attributes pre-computed to fit the ONNX spec."""
+
+    # NOTE: transposed must be an input because when provided as an attribute,
+    # it will be an integer, not a boolean, which will fail the if condition.
+    # Alternatively we could cast transposed to BOOL.
+    # E.g. `if op.Cast(transposed, BOOL.dtype): ...`
 
     weight_size = op.Size(op.Shape(weight))
     no_batch = op.Size(op.Shape(input)) != weight_size

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -1235,7 +1235,7 @@ def _aten_convolution_onnx(
     strides: Sequence[int],
     pads: Sequence[int],
     dilations: Sequence[int],
-    output_padding: Sequence[int] = [0],
+    output_padding: Sequence[int] = (0,),
     groups: int = 1,
 ) -> TFloat:
     """ConvXd with attributes pre-computed to fit the ONNX spec."""


### PR DESCRIPTION
- Support adding BOOL constants in graph_builder
- Fix type error in `_aten_convolution_onnx` where the `cond` to if is `int64` if `transposed` were an attribute
- Enable model checker in TorchScriptGraph