### PR TITLE
chore: remove autopep8

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,6 @@ nox.options.error_on_missing_interpreters = False
 
 
 COMMON_TEST_DEPENDENCIES = (
-    "autopep8",
     "click",
     "jinja2",
     'numpy==1.23.5; python_version>="3.8"',

--- a/onnxscript/backend/onnx_export.py
+++ b/onnxscript/backend/onnx_export.py
@@ -406,7 +406,6 @@ def export_template(
     template,
     name=None,
     function_name="main_function",
-    clean_code=True,
     use_operators=False,
     rename=False,
     inline_const: bool = False,
@@ -418,7 +417,6 @@ def export_template(
         template: exporting template
         name: to overwrite onnx name
         function_name: main function name in the code
-        clean_code: clean the code
         use_operators: use Python operators.
         rename: rename variable name to get shorter names
         inline_const: replace ONNX constants inline if compact
@@ -528,7 +526,6 @@ def export2python(
     rename=False,
     function_name="main",
     use_operators=False,
-    clean_code=True,
     inline_const: bool = False,
 ):
     """Exports an ONNX model to the *python* syntax.
@@ -542,7 +539,6 @@ def export2python(
         rename: rename the names to get shorter names
         function_name: main function name
         use_operators: use Python operators.
-        clean_code: clean the code
         inline_const: replace ONNX constants inline if compact
 
     Returns:
@@ -574,7 +570,6 @@ def export2python(
         model_onnx,
         template=_template_python,
         name=name,
-        clean_code=clean_code,
         function_name=function_name,
         use_operators=use_operators,
         rename=rename,

--- a/onnxscript/backend/onnx_export.py
+++ b/onnxscript/backend/onnx_export.py
@@ -405,7 +405,6 @@ def export_template(
     model_onnx,
     template,
     name=None,
-    autopep_options=None,
     function_name="main_function",
     clean_code=True,
     use_operators=False,
@@ -418,7 +417,6 @@ def export_template(
         model_onnx: string or ONNX graph
         template: exporting template
         name: to overwrite onnx name
-        autopep_options: :epkg:`autopep8` options
         function_name: main function name in the code
         clean_code: clean the code
         use_operators: use Python operators.
@@ -518,14 +516,7 @@ def export_template(
     final += "\n"
     if "\nreturn" in final:
         raise SyntaxError(f"The produced code is wrong.\n{final}")
-    if clean_code:
-        # delayed import to avoid raising an exception if not installed.
-        import autopep8  # pylint: disable=import-outside-toplevel
 
-        cleaned_code = autopep8.fix_code(final, options=autopep_options)
-        if "\nreturn" in cleaned_code:
-            raise SyntaxError(f"The cleaned code is wrong.\n{final}\n------{cleaned_code}")
-        return cleaned_code
     return final
 
 
@@ -535,7 +526,6 @@ def export2python(
     verbose=True,
     name=None,
     rename=False,
-    autopep_options=None,
     function_name="main",
     use_operators=False,
     clean_code=True,
@@ -550,7 +540,6 @@ def export2python(
         verbose: inserts prints
         name: to overwrite onnx name
         rename: rename the names to get shorter names
-        autopep_options: :epkg:`autopep8` options
         function_name: main function name
         use_operators: use Python operators.
         clean_code: clean the code
@@ -585,7 +574,6 @@ def export2python(
         model_onnx,
         template=_template_python,
         name=name,
-        autopep_options=autopep_options,
         clean_code=clean_code,
         function_name=function_name,
         use_operators=use_operators,

--- a/onnxscript/tests/external_tensor_test.py
+++ b/onnxscript/tests/external_tensor_test.py
@@ -34,7 +34,7 @@ class TestConverter(unittest.TestCase):
             )
 
             # Convert model to python:
-            pymodel = proto2python(model, clean_code=False)
+            pymodel = proto2python(model)
             self.assertIn(
                 "external_tensor('weight', 1, [1024, 10], 'weight', length=40960)", pymodel
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ show_column_numbers = true
 module = [
   "onnx.*",
   "onnxruntime.*",
-  "autopep8.*",
   "parameterized.*",
   "torchgen.*",
 ]


### PR DESCRIPTION
autopep8 is slow. We remove it and eventually should move to use Aaron's code gen module.