### PR TITLE
feat(eager): turn Evaluator into a Protocol

### DIFF
--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -204,6 +204,9 @@ class TorchScriptTracingEvaluator(evaluator.Evaluator):
     def graph(self) -> TorchScriptGraph:
         return self._graph
 
+    def eval(self, schema, inputs, attributes):
+        return self._graph.add_op_call(schema, inputs, attributes)
+
     @beartype
     def eval_function(  # type: ignore[override]
         self,
@@ -224,14 +227,6 @@ class TorchScriptTracingEvaluator(evaluator.Evaluator):
                 # FIXME(justinchuby): Create invariant on the type of param.type to simplify this
                 attributes[name] = float(value)
         return self._graph.add_function_call(function, inputs, attributes)
-
-    def _eval(self, schema: onnx.defs.OpSchema, inputs, attributes, closure: Any):
-        del closure  # Unused
-
-        return self._graph.add_op_call(schema, inputs, attributes)
-
-    def eval(self, schema, inputs, attributes):
-        return self._eval(schema, inputs, attributes, closure=None)
 
 
 @beartype


### PR DESCRIPTION
Make Evaluator a Protocol and change the old evaluator into BaseEvaluator. This way other evaluators like TorchScriptEvaluator that does not require input adaptation don't need to carry all the base methods. It also frees them from having to implement the indirect `_eval` method, making the programmatic api cleaner.