### PR TITLE
chore(lint): disallow relative imports

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -26,7 +26,7 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.0.246',
+    'ruff==0.0.248',
 ]
 
 [[linter]]
@@ -55,7 +55,7 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.0.246',
+    'ruff==0.0.248',
 ]
 is_formatter = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,5 @@ unfixable = [
 # Disallow all relative imports.
 ban-relative-imports = "all"
 
-
 [tool.ruff.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ select = [
     "N", # pep8-naming
     "YTT", # flake8-2020
     "RUF", # Ruff-specific rules
+    "TID252", # Disallow relative imports
 ]
 ignore = [
     "D1", # D1 is for missing docstrings, which is not yet enforced.
@@ -138,6 +139,11 @@ ignore-init-module-imports = true
 unfixable = [
     "F401", # Unused imports
 ]
+
+[tool.ruff.flake8-tidy-imports]
+# Disallow all relative imports.
+ban-relative-imports = "all"
+
 
 [tool.ruff.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,10 +129,11 @@ ignore = [
     "D400",
     "D401", # First line of docstring should be in imperative mood
     "D415", # D415 Not yet enforced. "First line should end with a period, question mark, or exclamation point"
-    "E501",
+    "E501", # Line length. Not enforced because black will handle formatting
     "N802", # Nxx: ONNX Script function sometimes use upper case for names.
     "N803",
     "N806",
+    "N999", # Invalid module name
 ]
 line-length = 120
 ignore-init-module-imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,3 +147,6 @@ ban-relative-imports = "all"
 
 [tool.ruff.pydocstyle]
 convention = "google"
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["TID252"] # Allow relative imports in init files


### PR DESCRIPTION
Enable `TID252` in ruff but allow relative imports in init files.