### PR TITLE
feat(atenlib): test random ops

### DIFF
--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -407,7 +407,7 @@ OPINFO_FUNCTION_MAPPING_TRACE_ONLY: dict[
 }
 
 # These ops are not deterministic, so we check shape and dtype only
-UNDETERMINISTIC_OPS: frozenset[str] = frozenset(
+INDETERMINISTIC_OPS: frozenset[str] = frozenset(
     (
         "empty_like",
         "empty",
@@ -570,9 +570,9 @@ OP_WITH_SKIPPED_SUBTESTS = frozenset(meta.op_name for meta in SKIP_SUBTESTS)
 ALL_OPS_IN_DB = frozenset(op_info.name for op_info in OPS_DB)
 # Assert all ops in OPINFO_FUNCTION_MAPPING are in the OPS_DB
 assert TESTED_OPS.issubset(ALL_OPS_IN_DB), f"{TESTED_OPS - ALL_OPS_IN_DB} not in OPS_DB"
-assert UNDETERMINISTIC_OPS.issubset(
+assert INDETERMINISTIC_OPS.issubset(
     TESTED_OPS
-), f"{UNDETERMINISTIC_OPS - TESTED_OPS} not in OPS_DB"
+), f"{INDETERMINISTIC_OPS - TESTED_OPS} not in OPS_DB"
 
 TORCH_TYPE_TO_ONNX = {
     torch.bool: onnx.TensorProto.BOOL,
@@ -772,9 +772,9 @@ class TestOutputConsistency(unittest.TestCase):
                         else torch.tensor(torch_output)
                     )
 
-                    if op.name in UNDETERMINISTIC_OPS:
+                    if op.name in INDETERMINISTIC_OPS:
                         # Check shape and dtype only for ops that are known to be
-                        # undeterministic
+                        # indeterministic
                         self.assertEqual(actual.shape, expected.shape)
                         self.assertEqual(actual.dtype, expected.dtype)
                         continue

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -572,7 +572,7 @@ ALL_OPS_IN_DB = frozenset(op_info.name for op_info in OPS_DB)
 assert TESTED_OPS.issubset(ALL_OPS_IN_DB), f"{TESTED_OPS - ALL_OPS_IN_DB} not in OPS_DB"
 assert INDETERMINISTIC_OPS.issubset(
     TESTED_OPS
-), f"{INDETERMINISTIC_OPS - TESTED_OPS} not in OPS_DB"
+), f"{INDETERMINISTIC_OPS - TESTED_OPS} not in TESTED_OPS"
 
 TORCH_TYPE_TO_ONNX = {
     torch.bool: onnx.TensorProto.BOOL,

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -111,7 +111,7 @@ def skip(
         reason: The reason for skipping.
         dtypes: The dtypes to skip.
         matcher: A function that matches the test sample input. It is used only when
-            xfail is in the SKIP_SUBTESTS list.
+            the skip is in the SKIP_SUBTESTS list.
         active_if: Whether the skip is active.
     """
     return DecorateMeta(

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -407,7 +407,7 @@ OPINFO_FUNCTION_MAPPING_TRACE_ONLY: dict[
 }
 
 # These ops are not deterministic, so we check shape and dtype only
-UNDETERMINISTIC_OPS = frozenset(
+UNDETERMINISTIC_OPS: frozenset[str] = frozenset(
     (
         "empty_like",
         "empty",
@@ -570,7 +570,9 @@ OP_WITH_SKIPPED_SUBTESTS = frozenset(meta.op_name for meta in SKIP_SUBTESTS)
 ALL_OPS_IN_DB = frozenset(op_info.name for op_info in OPS_DB)
 # Assert all ops in OPINFO_FUNCTION_MAPPING are in the OPS_DB
 assert TESTED_OPS.issubset(ALL_OPS_IN_DB), f"{TESTED_OPS - ALL_OPS_IN_DB} not in OPS_DB"
-
+assert UNDETERMINISTIC_OPS.issubset(
+    TESTED_OPS
+), f"{UNDETERMINISTIC_OPS - TESTED_OPS} not in OPS_DB"
 
 TORCH_TYPE_TO_ONNX = {
     torch.bool: onnx.TensorProto.BOOL,

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -64,7 +64,7 @@ class DecorateMeta:
     dtypes: Optional[Collection[torch.dtype]]
     reason: str
     matcher: Optional[Callable[[Any], bool]] = None
-    active_if: bool = True
+    enabled_if: bool = True
 
 
 def xfail(
@@ -73,7 +73,7 @@ def xfail(
     *,
     reason: str,
     dtypes: Optional[Collection[torch.dtype]] = None,
-    active_if: bool = True,
+    enabled_if: bool = True,
 ) -> DecorateMeta:
     """Expects an OpInfo test to fail.
 
@@ -82,7 +82,7 @@ def xfail(
         variant_name: Optional OpInfo variant_test_name.
         reason: The reason for the failure.
         dtypes: The dtypes to expect the failure.
-        active_if: Whether the xfail is active.
+        enabled_if: Whether the xfail is enabled.
     """
     return DecorateMeta(
         op_name=op_name,
@@ -90,7 +90,7 @@ def xfail(
         decorator=unittest.expectedFailure,
         dtypes=dtypes,
         reason=reason,
-        active_if=active_if,
+        enabled_if=enabled_if,
     )
 
 
@@ -101,7 +101,7 @@ def skip(
     reason: str,
     dtypes: Optional[Collection[torch.dtype]] = None,
     matcher: Optional[Callable[[Any], Any]] = None,
-    active_if: bool = True,
+    enabled_if: bool = True,
 ) -> DecorateMeta:
     """Skips an OpInfo test.
 
@@ -112,7 +112,7 @@ def skip(
         dtypes: The dtypes to skip.
         matcher: A function that matches the test sample input. It is used only when
             the skip is in the SKIP_SUBTESTS list.
-        active_if: Whether the skip is active.
+        enabled_if: Whether the skip is enabled.
     """
     return DecorateMeta(
         op_name=op_name,
@@ -121,7 +121,7 @@ def skip(
         dtypes=dtypes,
         reason=reason,
         matcher=matcher,
-        active_if=active_if,
+        enabled_if=enabled_if,
     )
 
 
@@ -144,7 +144,7 @@ def add_decorate_info(
             test_class_name,
             base_test_name,
             dtypes=decorate_meta.dtypes,
-            active_if=decorate_meta.active_if,
+            active_if=decorate_meta.enabled_if,
         )
         decorators.append(new_decorator)
         opinfo.decorators = tuple(decorators)
@@ -433,12 +433,12 @@ EXPECTED_SKIPS_OR_FAILS = (
     xfail(
         "logsumexp",
         reason="ONNX Runtime 1.13 does not support ReduceLogSumExp-18",
-        active_if=version_utils.onnxruntime_older_than("1.14"),
+        enabled_if=version_utils.onnxruntime_older_than("1.14"),
     ),
     xfail(
         "nn.functional.upsample_nearest2d",
         reason="ONNX Runtime 1.13 does support opset18",
-        active_if=version_utils.onnxruntime_older_than("1.14"),
+        enabled_if=version_utils.onnxruntime_older_than("1.14"),
     ),
     xfail("logcumsumexp", reason="naive implementation not numerically stable"),
     xfail("round", variant_name="decimals_0", reason="The op does not support decimals"),

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -407,7 +407,7 @@ OPINFO_FUNCTION_MAPPING_TRACE_ONLY: dict[
 }
 
 # These ops are not deterministic, so we check shape and dtype only
-INDETERMINISTIC_OPS: frozenset[str] = frozenset(
+NONDETERMINISTIC_OPS: frozenset[str] = frozenset(
     (
         "empty_like",
         "empty",
@@ -570,9 +570,9 @@ OP_WITH_SKIPPED_SUBTESTS = frozenset(meta.op_name for meta in SKIP_SUBTESTS)
 ALL_OPS_IN_DB = frozenset(op_info.name for op_info in OPS_DB)
 # Assert all ops in OPINFO_FUNCTION_MAPPING are in the OPS_DB
 assert TESTED_OPS.issubset(ALL_OPS_IN_DB), f"{TESTED_OPS - ALL_OPS_IN_DB} not in OPS_DB"
-assert INDETERMINISTIC_OPS.issubset(
+assert NONDETERMINISTIC_OPS.issubset(
     TESTED_OPS
-), f"{INDETERMINISTIC_OPS - TESTED_OPS} not in TESTED_OPS"
+), f"{NONDETERMINISTIC_OPS - TESTED_OPS} not in TESTED_OPS"
 
 TORCH_TYPE_TO_ONNX = {
     torch.bool: onnx.TensorProto.BOOL,
@@ -772,9 +772,9 @@ class TestOutputConsistency(unittest.TestCase):
                         else torch.tensor(torch_output)
                     )
 
-                    if op.name in INDETERMINISTIC_OPS:
+                    if op.name in NONDETERMINISTIC_OPS:
                         # Check shape and dtype only for ops that are known to be
-                        # indeterministic
+                        # nondeterministic
                         self.assertEqual(actual.shape, expected.shape)
                         self.assertEqual(actual.dtype, expected.dtype)
                         continue


### PR DESCRIPTION
Check shape and dtype only for ops that are known to be indeterministic.
Also added the skip_if mechanism to skip tests based on environment.