### PR TITLE
enable -1 test in expand

### DIFF
--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -511,11 +511,6 @@ SKIP_SUBTESTS: tuple[DecorateMeta, ...] = (
         reason="rounding_mode is not yet supported",
     ),
     skip(
-        "expand",
-        matcher=lambda sample: (np.array(sample.args[0]) > 0).all() is np.bool_(False),
-        reason="Negative value is not supported",
-    ),
-    skip(
         "nonzero",
         matcher=lambda sample: sample.kwargs.get("as_tuple") is not None,
         reason="as_tuple=True is not supported",


### PR DESCRIPTION
Enable -1 test for op.Expand
Should be included in https://github.com/microsoft/onnx-script/pull/507