### PR TITLE
fix(test): bump onnxruntime, onnx, torch versions in noxfile.py

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ COMMON_TEST_DEPENDENCIES = (
 )
 ONNX = "onnx==1.13.1"
 ONNX_RUNTIME = "onnxruntime==1.14.1"
-PYTORCH = "torch==1.13.1"
+PYTORCH = "torch==1.13"
 
 
 @nox.session(tags=["build"])

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,9 +25,9 @@ COMMON_TEST_DEPENDENCIES = (
     "pytest!=7.1.0",
     "pyyaml",
 )
-ONNX = "onnx==1.13"
-ONNX_RUNTIME = "onnxruntime==1.14"
-PYTORCH = "torch==1.13"
+ONNX = "onnx==1.13.1"
+ONNX_RUNTIME = "onnxruntime==1.14.1"
+PYTORCH = "torch==1.13.1"
 
 
 @nox.session(tags=["build"])

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,7 +25,7 @@ COMMON_TEST_DEPENDENCIES = (
     "pytest!=7.1.0",
     "pyyaml",
 )
-ONNX = "onnx==1.13"
+ONNX = "onnx==1.13.1"
 ONNX_RUNTIME = "onnxruntime==1.14.1"
 PYTORCH = "torch==1.13.1"
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,9 +25,9 @@ COMMON_TEST_DEPENDENCIES = (
     "pytest!=7.1.0",
     "pyyaml",
 )
-ONNX = "onnx==1.13.1"
+ONNX = "onnx==1.13"
 ONNX_RUNTIME = "onnxruntime==1.14.1"
-PYTORCH = "torch==1.13"
+PYTORCH = "torch==1.13.1"
 
 
 @nox.session(tags=["build"])

--- a/onnxscript/backend/onnx_export_test.py
+++ b/onnxscript/backend/onnx_export_test.py
@@ -14,7 +14,6 @@ from typing import Pattern
 import onnxruntime as ort
 import parameterized
 from onnxruntime.capi import onnxruntime_pybind11_state
-from packaging.version import Version
 
 import onnxscript
 from onnxscript.backend import onnx_backend, onnx_export

--- a/onnxscript/backend/onnx_export_test.py
+++ b/onnxscript/backend/onnx_export_test.py
@@ -160,9 +160,7 @@ class TestOnnxBackEnd(unittest.TestCase):
             onnxruntime_pybind11_state.InvalidArgument,  # pylint: disable=c-extension-no-member
         ) as e:
             self.skipTest(f"Unable to load the model: {e}")
-        except (
-            onnxruntime_pybind11_state.RuntimeException
-        ) as e:  # pylint: disable=c-extension-no-member
+        except onnxruntime_pybind11_state.RuntimeException as e:  # pylint: disable=c-extension-no-member
             self.skipTest(f"Unable to run the model: {e}")
         except AssertionError as e:
             self.skipTest(f"ORT result mismatches with the expected: {e}")

--- a/onnxscript/backend/onnx_export_test.py
+++ b/onnxscript/backend/onnx_export_test.py
@@ -63,7 +63,7 @@ SKIP_TESTS = (
     skip(
         r"^test_optional_get_element_tensor",
         "ORT Unable to create onnxruntime InferenceSession for executing .OptionalGetElement op with onnx model",
-        condition=ort.__version__ == "1.14.0",
+        condition=ort.__version__ == "1.14.1",
     ),
     skip(
         r"test_loop",

--- a/onnxscript/backend/onnx_export_test.py
+++ b/onnxscript/backend/onnx_export_test.py
@@ -14,6 +14,7 @@ from typing import Pattern
 import onnxruntime as ort
 import parameterized
 from onnxruntime.capi import onnxruntime_pybind11_state
+from packaging.version import Version
 
 import onnxscript
 from onnxscript.backend import onnx_backend, onnx_export
@@ -63,7 +64,7 @@ SKIP_TESTS = (
     skip(
         r"^test_optional_get_element_tensor",
         "ORT Unable to create onnxruntime InferenceSession for executing .OptionalGetElement op with onnx model",
-        condition=ort.__version__ == "1.14.1",
+        condition=Version(ort.__version__).base_version == "1.14",
     ),
     skip(
         r"test_loop",
@@ -123,7 +124,6 @@ def exec_main(f, *inputs):
 
 
 class TestOnnxBackEnd(unittest.TestCase):
-
     test_folder = pathlib.Path(__file__).parent.parent / "tests" / "onnx_backend_test_code"
 
     def test_export2python(self):
@@ -161,7 +161,9 @@ class TestOnnxBackEnd(unittest.TestCase):
             onnxruntime_pybind11_state.InvalidArgument,  # pylint: disable=c-extension-no-member
         ) as e:
             self.skipTest(f"Unable to load the model: {e}")
-        except onnxruntime_pybind11_state.RuntimeException as e:  # pylint: disable=c-extension-no-member
+        except (
+            onnxruntime_pybind11_state.RuntimeException
+        ) as e:  # pylint: disable=c-extension-no-member
             self.skipTest(f"Unable to run the model: {e}")
         except AssertionError as e:
             self.skipTest(f"ORT result mismatches with the expected: {e}")

--- a/onnxscript/backend/onnx_export_test.py
+++ b/onnxscript/backend/onnx_export_test.py
@@ -64,7 +64,7 @@ SKIP_TESTS = (
     skip(
         r"^test_optional_get_element_tensor",
         "ORT Unable to create onnxruntime InferenceSession for executing .OptionalGetElement op with onnx model",
-        condition=Version(ort.__version__).base_version == "1.14",
+        condition=ort.__version__[:4] == "1.14",
     ),
     skip(
         r"test_loop",

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -462,16 +462,6 @@ OPINFO_FUNCTION_MAPPING: dict[
 TESTED_OPS = frozenset(OPINFO_FUNCTION_MAPPING)
 
 EXPECTED_SKIPS_OR_FAILS = (
-    xfail(
-        "logsumexp",
-        reason="ONNX Runtime 1.13 does not support ReduceLogSumExp-18",
-        enabled_if=version_utils.onnxruntime_older_than("1.14.1"),
-    ),
-    xfail(
-        "nn.functional.upsample_nearest2d",
-        reason="ONNX Runtime 1.13 does support opset18",
-        enabled_if=version_utils.onnxruntime_older_than("1.14.1"),
-    ),
     xfail("logcumsumexp", reason="naive implementation not numerically stable"),
     xfail("round", variant_name="decimals_0", reason="The op does not support decimals"),
     xfail("round", variant_name="decimals_3", reason="The op does not support decimals"),

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -465,12 +465,12 @@ EXPECTED_SKIPS_OR_FAILS = (
     xfail(
         "logsumexp",
         reason="ONNX Runtime 1.13 does not support ReduceLogSumExp-18",
-        enabled_if=version_utils.onnxruntime_older_than("1.14"),
+        enabled_if=version_utils.onnxruntime_older_than("1.14.1"),
     ),
     xfail(
         "nn.functional.upsample_nearest2d",
         reason="ONNX Runtime 1.13 does support opset18",
-        enabled_if=version_utils.onnxruntime_older_than("1.14"),
+        enabled_if=version_utils.onnxruntime_older_than("1.14.1"),
     ),
     xfail("logcumsumexp", reason="naive implementation not numerically stable"),
     xfail("round", variant_name="decimals_0", reason="The op does not support decimals"),

--- a/onnxscript/tests/functions/onnxfns2_test.py
+++ b/onnxscript/tests/functions/onnxfns2_test.py
@@ -116,7 +116,7 @@ class TestOnnxFns(onnx_script_test_case.OnnxScriptTestCase):
     #         skip_test_names=[])
 
     @unittest.skipIf(
-        Version(onnxruntime.__version__).base_version == "1.14",
+        onnxruntime.__version__[:4] == "1.14",
         reason="onnxruntime 1.14 Segfaults.",
     )
     def test_onnxfns_space_to_depth(self):

--- a/onnxscript/tests/functions/onnxfns2_test.py
+++ b/onnxscript/tests/functions/onnxfns2_test.py
@@ -116,11 +116,10 @@ class TestOnnxFns(onnx_script_test_case.OnnxScriptTestCase):
     #         skip_test_names=[])
 
     @unittest.skipIf(
-        Version(onnxruntime.__version__) == Version("1.14.1"),
+        Version(onnxruntime.__version__).base_version == "1.14",
         reason="onnxruntime 1.14 Segfaults.",
     )
     def test_onnxfns_space_to_depth(self):
-
         self.run_onnx_test(onnxfns2.SpaceToDepth, skip_test_names=[], skip_eager_test=True)
 
 

--- a/onnxscript/tests/functions/onnxfns2_test.py
+++ b/onnxscript/tests/functions/onnxfns2_test.py
@@ -116,7 +116,7 @@ class TestOnnxFns(onnx_script_test_case.OnnxScriptTestCase):
     #         skip_test_names=[])
 
     @unittest.skipIf(
-        Version(onnxruntime.__version__) == Version("1.14"),
+        Version(onnxruntime.__version__) == Version("1.14.1"),
         reason="onnxruntime 1.14 Segfaults.",
     )
     def test_onnxfns_space_to_depth(self):


### PR DESCRIPTION
I saw an error comes from certain Python 3.9 CI pipeline: `'/Users/runner/work/onnx-script/onnx-script/.nox/test/lib/python3.9/site-packages/onnxruntime/capi/onnxruntime_pybind11_state.so' (mach-o file, but is an incompatible architecture (have (arm64), need (x86_64)))`, which is fixed by the latest ONNX Runtime 1.14.1: https://github.com/microsoft/onnxruntime/issues/14663. Bumping onnxruntime version here should help. Meanwhile, also try to bump onnx and torch to the latest patch release, which should be harmless.