### PR TITLE
chore(ci): run tests in random order

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -28,6 +28,7 @@ COMMON_TEST_DEPENDENCIES = (
 ONNX = "onnx==1.13.1"
 ONNX_RUNTIME = "onnxruntime==1.14.1"
 PYTORCH = "torch==1.13.1"
+PYTEST_RANDOMLY = "pytest-randomly"
 
 
 @nox.session(tags=["build"])
@@ -102,3 +103,19 @@ def test_onnx_weekly(session):
     session.install(".", "--no-deps")
     session.run("pip", "list")
     session.run("pytest", "onnxscript", *session.posargs)
+
+
+@nox.session(tags=["test-random-ordering"])
+def test_random_ordering(session):
+    """Run onnxscript test in random order to reduce test dependencies."""
+    session.install(
+        *COMMON_TEST_DEPENDENCIES,
+        PYTORCH,
+        ONNX,
+        ONNX_RUNTIME,
+        PYTEST_RANDOMLY,
+    )
+    session.install(".", "--no-deps")
+    session.run("pip", "list")
+    session.run("pytest", "onnxscript", *session.posargs)
+    session.run("pytest", "docs/test", *session.posargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,9 +20,9 @@ COMMON_TEST_DEPENDENCIES = (
     "packaging",
     "parameterized",
     "pytest-cov",
+    "pytest-randomly",
     "pytest-subtests",
     "pytest-xdist",
-    "pytest-randomly",
     "pytest!=7.1.0",
     "pyyaml",
 )

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,13 +22,13 @@ COMMON_TEST_DEPENDENCIES = (
     "pytest-cov",
     "pytest-subtests",
     "pytest-xdist",
+    "pytest-randomly",
     "pytest!=7.1.0",
     "pyyaml",
 )
 ONNX = "onnx==1.13.1"
 ONNX_RUNTIME = "onnxruntime==1.14.1"
 PYTORCH = "torch==1.13.1"
-PYTEST_RANDOMLY = "pytest-randomly"
 
 
 @nox.session(tags=["build"])
@@ -103,19 +103,3 @@ def test_onnx_weekly(session):
     session.install(".", "--no-deps")
     session.run("pip", "list")
     session.run("pytest", "onnxscript", *session.posargs)
-
-
-@nox.session(tags=["test-random-ordering"])
-def test_random_ordering(session):
-    """Run onnxscript test in random order to reduce test dependencies."""
-    session.install(
-        *COMMON_TEST_DEPENDENCIES,
-        PYTORCH,
-        ONNX,
-        ONNX_RUNTIME,
-        PYTEST_RANDOMLY,
-    )
-    session.install(".", "--no-deps")
-    session.run("pip", "list")
-    session.run("pytest", "onnxscript", *session.posargs)
-    session.run("pytest", "docs/test", *session.posargs)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,6 +20,7 @@ beartype
 expecttest
 parameterized
 pytest-cov
+pytest-randomly
 pytest-subtests
 pytest-xdist
 pytest!=7.1.0


### PR DESCRIPTION
https://pypi.org/project/pytest-randomly/

Tests are still reproducible locally by supplying the random seed from CI:

![image](https://user-images.githubusercontent.com/11205048/224383334-19112a11-89b4-41a8-bfd5-5f292b040972.png)


> Randomness in testing can be quite powerful to discover hidden flaws in the tests themselves, as well as giving a little more coverage to your system.
>
> By randomly ordering the tests, the risk of surprising inter-test dependencies is reduced - a technique used in many places, for example Google’s C++ test runner googletest. Research suggests that “dependent tests do exist in practice” and a random order of test executions can effectively detect such dependencies [1]. Alternatively, a reverse order of test executions, as provided by pytest-reverse, may find less dependent tests but can achieve a better benefit/cost ratio.