### PR TITLE
chore(test): test atenlib with TorchScriptEvaluator

### DIFF
--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -316,17 +316,15 @@ class TorchScriptGraph:
     ) -> TorchScriptTensor:
         # TODO: Take in a TorchScriptTensor?
         # TODO: Support dynamic shapes
+        torch_value = self._torch_graph.addInput(input_name)
         if input_value is None:
             # This input argument is None, which is mapped
             # to a NULL value in TorchScript type system.
-            torch_value = _create_op_call_in_torch_graph(
-                self._torch_graph, "prim::Constant", inputs=(), attributes={}
-            )[0]
+            # We keep the input instead of replacing it with a constant to
+            # preserve the input signature.
             torch_value.setType(torch.OptionalType.ofTensor())
-            tensor_value = _wrap_torch_value_to_tensor(torch_value)
-            return tensor_value  # type: ignore[return-value]
-        torch_value = self._torch_graph.addInput(input_name)
-        torch_value.setType(torch.TensorType.create_from_tensor(input_value))
+        else:
+            torch_value.setType(torch.TensorType.create_from_tensor(input_value))
         tensor_value = _wrap_torch_value_to_tensor(torch_value)
         return tensor_value  # type: ignore[return-value]
 

--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -486,6 +486,8 @@ class TorchScriptGraph:
             onnx.checker.check_model(onnx_model, full_check=True)
         except onnx.checker.ValidationError as e:
             warnings.warn(f"ONNX model is invalid: {e}")
+        except onnx.shape_inference.InferenceError as e:
+            raise RuntimeError(f"ONNX model is invalid:\n{onnxscript.proto2text(onnx_model)}") from e
 
         return onnx_model
 

--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -95,12 +95,11 @@ class TorchScriptTensor(onnxscript_tensor.Tensor):
         self._name = name
         self._torch_value.setDebugName(name)
 
-    @property
-    def rank(self) -> int:
+    @property  # type: ignore[override]
+    def rank(self) -> int | None:
         value_type = self._torch_value.type()
         if value_type is None:
-            # Use -1 to indicate unknown rank to maintain int output
-            return -1
+            return None
         value_type = typing.cast(torch.TensorType, value_type)
         return value_type.dim()
 

--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -487,7 +487,10 @@ class TorchScriptGraph:
         except onnx.checker.ValidationError as e:
             warnings.warn(f"ONNX model is invalid: {e}")
         except onnx.shape_inference.InferenceError as e:
-            raise RuntimeError(f"ONNX model is invalid:\n{onnxscript.proto2text(onnx_model)}") from e
+            raise RuntimeError(
+                f"ONNX model is invalid:\n{onnxscript.proto2text(onnx_model)}\n"
+                f"TorchScript graph:\n{self.torch_graph}\n"
+            ) from e
 
         return onnx_model
 

--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -1,5 +1,6 @@
 """Graph building functions for torchscript graph backend."""
 from __future__ import annotations
+import logging
 
 import typing
 import warnings
@@ -484,13 +485,13 @@ class TorchScriptGraph:
         )
         try:
             onnx.checker.check_model(onnx_model, full_check=True)
-        except onnx.checker.ValidationError as e:
+        except (onnx.checker.ValidationError, onnx.shape_inference.InferenceError) as e:
             warnings.warn(f"ONNX model is invalid: {e}")
-        except onnx.shape_inference.InferenceError as e:
-            raise RuntimeError(
-                f"ONNX model is invalid:\n{onnxscript.proto2text(onnx_model)}\n"
-                f"TorchScript graph:\n{self.torch_graph}\n"
-            ) from e
+            logging.debug(
+                "ONNX model:\n%s\n\nTorchScript graph:\n%s",
+                onnxscript.proto2text(onnx_model),
+                self.torch_graph,
+            )
 
         return onnx_model
 

--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -481,7 +481,7 @@ class TorchScriptGraph:
             function_proto_list.append(onnx_function.to_function_proto())
         onnx_model.functions.extend(function_proto_list)
         onnx_model = onnx.shape_inference.infer_shapes(
-            onnx_model, check_type=True, strict_mode=False
+            onnx_model, check_type=True, strict_mode=False, data_prop=True
         )
         try:
             onnx.checker.check_model(onnx_model, full_check=True)

--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -316,15 +316,17 @@ class TorchScriptGraph:
     ) -> TorchScriptTensor:
         # TODO: Take in a TorchScriptTensor?
         # TODO: Support dynamic shapes
-        torch_value = self._torch_graph.addInput(input_name)
         if input_value is None:
             # This input argument is None, which is mapped
             # to a NULL value in TorchScript type system.
-            # We keep the input instead of replacing it with a constant to
-            # preserve the input signature.
+            torch_value = _create_op_call_in_torch_graph(
+                self._torch_graph, "prim::Constant", inputs=(), attributes={}
+            )[0]
             torch_value.setType(torch.OptionalType.ofTensor())
-        else:
-            torch_value.setType(torch.TensorType.create_from_tensor(input_value))
+            tensor_value = _wrap_torch_value_to_tensor(torch_value)
+            return tensor_value  # type: ignore[return-value]
+        torch_value = self._torch_graph.addInput(input_name)
+        torch_value.setType(torch.TensorType.create_from_tensor(input_value))
         tensor_value = _wrap_torch_value_to_tensor(torch_value)
         return tensor_value  # type: ignore[return-value]
 

--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -1,7 +1,7 @@
 """Graph building functions for torchscript graph backend."""
 from __future__ import annotations
-import logging
 
+import logging
 import typing
 import warnings
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union

--- a/onnxscript/function_libs/torch_aten/graph_building_test.py
+++ b/onnxscript/function_libs/torch_aten/graph_building_test.py
@@ -17,10 +17,7 @@ from onnxscript.tests.common import version_utils
 @unittest.skipIf(version_utils.torch_older_than("2.0"), "torchscript in 1.13 not supported")
 class TestTorchScriptTracingEvaluator(unittest.TestCase):
     def setUp(self):
-        # FIXME: Currently this must match with the import line
-        # `from onnxscript import opset17 as op`, which restricts opset to be 17 in these
-        # tests anyways.
-        self.opset_version = 17
+        self.opset_version = 18
         # TODO: Add test for initializer. Currently skipped since to `assert_isomorphic`
         # does not check for initializers.
         self.onnxscript_graph = graph_building.TorchScriptGraph()

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -200,53 +200,27 @@ def aten_alpha_dropout(input: TensorType, p: float, train: bool) -> TensorType:
     raise NotImplementedError()
 
 
-@torch_op("aten::amax", trace_only=True)
-def aten_amax(self: TReal, dim: Optional[int] = None, keepdim: bool = False) -> TReal:
+@torch_op("aten::amax")
+def aten_amax(self: TReal, dim: INT64, keepdim: bool = False) -> TReal:
     """amax(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor"""
 
-    # TODO(justinchuby): Make dim INT64 after we upgrade to onnxruntime 1.14
-    if dim is None:
-        return opset17.ReduceMax(self, keepdims=keepdim)
-    if not isinstance(dim, Sequence):
-        dims = [dim]
+    dim_is_empty = op.Size(dim) == 0
+    if dim_is_empty:
+        result = op.ReduceMax(self, keepdims=keepdim)
     else:
-        dims = list(dim)
-    return _aten_amax_onnx(self, axes=dims, keepdims=keepdim)
-
-
-@torch_op("aten::amax", overload=True)
-def _aten_amax_onnx(self: TReal, axes: Sequence[int], keepdims: bool) -> TReal:
-    """TODO(justinchuby): Use opset18 after we upgrade to onnxruntime 1.14"""
-    if opset17.Size(opset17.Shape(self)) == 0:
-        # Scalar
-        result = self
-    else:
-        result = opset17.ReduceMax(self, axes=axes, keepdims=keepdims)
+        result = op.ReduceMax(self, axes, keepdims=keepdims)
     return result
 
 
-@torch_op("aten::amin", trace_only=True)
-def aten_amin(self: TReal, dim: Optional[int] = None, keepdim: bool = False) -> TReal:
+@torch_op("aten::amin")
+def aten_amin(self: TReal, dim: INT64, keepdim: bool = False) -> TReal:
     """amin(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor"""
 
-    # TODO(justinchuby): Make dim INT64 after we upgrade to onnxruntime 1.14
-    if dim is None:
-        return opset17.ReduceMin(self, keepdims=keepdim)
-    if not isinstance(dim, Sequence):
-        dims = [dim]
+    dim_is_empty = op.Size(dim) == 0
+    if dim_is_empty:
+        result = op.ReduceMin(self, keepdims=keepdim)
     else:
-        dims = list(dim)
-    return _aten_amin_onnx(self, axes=dims, keepdims=keepdim)
-
-
-@torch_op("aten::amin", overload=True)
-def _aten_amin_onnx(self: TReal, axes: Sequence[int], keepdims: bool) -> TReal:
-    """TODO(justinchuby): Use opset18 after we upgrade to onnxruntime 1.14"""
-    if opset17.Size(opset17.Shape(self)) == 0:
-        # Scalar
-        result = self
-    else:
-        result = opset17.ReduceMin(self, axes=axes, keepdims=keepdims)
+        result = op.ReduceMin(self, axes, keepdims=keepdims)
     return result
 
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -2969,11 +2969,11 @@ def aten_layer_norm(
 
     if weight is None:
         one = op.Constant(value_float=1.0)
-        weight = op.Expand(one, op.Shape(input, start=axis))
+        weight = op.Expand(one, op.Shape(input, start=start_axis))
 
     if bias is None:
         zero = op.Constant(value_float=0.0)
-        bias = op.Expand(zero, op.Shape(input, start=axis))
+        bias = op.Expand(zero, op.Shape(input, start=start_axis))
 
     return _aten_layer_norm_onnx(input, weight, bias, axis=start_axis, eps=eps)
 
@@ -4058,11 +4058,11 @@ def aten_native_layer_norm(
 
     if weight is None:
         one = op.Constant(value_floats=[1.0])
-        weight = op.Expand(one, op.Shape(input, start=axis))
+        weight = op.Expand(one, op.Shape(input, start=start_axis))
         weight = op.CastLike(weight, input)
 
     result, mean, rdenominator = op.LayerNormalization(
-        input, weight, bias, axis=axis, epsilon=eps
+        input, weight, bias, axis=start_axis, epsilon=eps
     )
 
     return result, mean, rdenominator

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -5508,7 +5508,7 @@ def aten_transpose(self, dim0: int, dim1: int):
     """transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)"""
 
     # Use trace only to construct the prem attribute in Transpose
-    self_rank = len(self)  # type: ignore[attr-defined]
+    self_rank = len(self.shape)  # type: ignore[attr-defined]
 
     if self_rank == 0:
         result = self

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -4052,16 +4052,16 @@ def _aten_native_layer_norm_onnx(
 
     if not op.OptionalHasElement(weight):
         one = op.Constant(value_floats=[1.0])
-        weight = op.Expand(one, op.Shape(input, start=start_axis))
+        weight = op.Expand(one, op.Shape(input, start=axis))
         weight = op.CastLike(weight, input)
 
     if not op.OptionalHasElement(bias):
         result, mean, rdenominator = op.LayerNormalization(
-            input, weight, axis=start_axis, epsilon=eps
+            input, weight, axis=axis, epsilon=eps
         )
     else:
         result, mean, rdenominator = op.LayerNormalization(
-            input, weight, bias, axis=start_axis, epsilon=eps
+            input, weight, bias, axis=axis, epsilon=eps
         )
 
     return result, mean, rdenominator

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -4003,7 +4003,7 @@ def aten_native_group_norm_backward(
 @torch_op("aten::native_layer_norm", trace_only=True)
 def aten_native_layer_norm(
     input: TReal,
-    normalized_shape: INT64,
+    normalized_shape: Sequence[int],
     weight: Optional[TReal],
     bias: Optional[TReal],
     eps: float,
@@ -5297,7 +5297,6 @@ def aten_symeig(
 def aten_t(self: TTensor) -> TTensor:
     """t(Tensor(a) self) -> Tensor(a)"""
 
-    # TODO(justinchuby): Make rank a function
     rank = op.Size(op.Shape(self))
     if rank == 0 or rank == 1:  # pylint: disable=consider-using-in
         result = self

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -4034,7 +4034,7 @@ def aten_native_layer_norm(
     # where D is the dimension of normalized_shape. For example, if normalized_shape is
     # (3, 5) (a 2-dimensional shape), the mean and standard-deviation are computed
     # over the last 2 dimensions of the input (i.e. input.mean((-2, -1))).
-    
+
     # Use Python to manipulate
     start_axis = -len(normalized_shape)
     return _aten_native_layer_norm_onnx(input, weight, bias, axis=start_axis, eps=eps)

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -1913,19 +1913,16 @@ def aten_dot(self: TFloat, tensor: TFloat) -> TFloat:
 
 
 @torch_op("aten::dropout")
-def aten_dropout(input: TFloat, p: float = 0.5, train: bool = True) -> TFloat:
+def aten_dropout(input: TFloat, p: FLOAT, train: BOOL) -> TFloat:
     """dropout(Tensor input, float p, bool train) -> Tensor"""
 
-    # The attribute train is actually int. So we need to cast it to a BOOL tensor.
-    train = op.Cast(train, to=BOOL.dtype)
-    rank_input = op.Size(op.Shape(input))
-    if rank_input == 0:
+    input_is_scalar = op.Size(op.Shape(input)) == 0
+    if input_is_scalar:
         input = op.Reshape(input, op.Constant(value_ints=[-1]))
-
-    result, _ = op.Dropout(input, p, train)
-
-    if rank_input == 0:
+        result, _ = op.Dropout(input, p, train)
         result = op.Squeeze(result)
+    else:
+        result, _ = op.Dropout(input, p, train)
 
     return result
 
@@ -3512,7 +3509,6 @@ def aten_min(self: TReal) -> TReal:
 
 @torch_op("aten::min", overload=True)
 def aten_min_dim(self: TReal, dim: int, keepdim: bool = False) -> Tuple[TReal, TInt]:
-
     if op.Size(op.Shape(self)) == 0:
         result = self
         indices = op.Constant(value_int=0)
@@ -3526,7 +3522,6 @@ def aten_min_dim(self: TReal, dim: int, keepdim: bool = False) -> Tuple[TReal, T
 
 @torch_op("aten::min", overload=True)
 def aten_min_other(self: TReal, other: TReal) -> TReal:
-
     return op.Min(self, other)
 
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -2990,7 +2990,6 @@ def _aten_layer_norm_onnx(
     return result
 
 
-
 def aten_lcm(self: TensorType, other: TensorType) -> TensorType:
     """lcm(Tensor self, Tensor other) -> Tensor"""
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -4003,22 +4003,19 @@ def aten_native_group_norm_backward(
 @torch_op("aten::native_layer_norm", trace_only=True)
 def aten_native_layer_norm(
     input: TReal,
-    normalized_shape: Sequence[int],
+    normalized_shape: INT64,
     weight: Optional[TReal],
     bias: Optional[TReal],
     eps: float,
 ) -> Tuple[TReal, TReal, TReal]:
     """native_layer_norm(Tensor input, SymInt[] normalized_shape, Tensor? weight, Tensor? bias, float eps) -> (Tensor, Tensor, Tensor)"""
 
-    # Use python to manipulate the axes
     # https://pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html#torch.nn.LayerNorm
     # The mean and standard-deviation are calculated over the last D dimensions,
     # where D is the dimension of normalized_shape. For example, if normalized_shape is
     # (3, 5) (a 2-dimensional shape), the mean and standard-deviation are computed
     # over the last 2 dimensions of the input (i.e. input.mean((-2, -1))).
-
-    axes_list = [-i for i in range(len(normalized_shape), 0, -1)]
-    start_axis = axes_list[0]
+    start_axis = op.Neg(op.Size(normalized_shape))
 
     if not op.OptionalHasElement(weight):
         one = op.Constant(value_floats=[1.0])

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -1891,6 +1891,8 @@ def aten_dot(self: TFloat, tensor: TFloat) -> TFloat:
 def aten_dropout(input: TFloat, p: float = 0.5, train: bool = True) -> TFloat:
     """dropout(Tensor input, float p, bool train) -> Tensor"""
 
+    # The attribute train is actually int. So we need to cast it to a BOOL tensor.
+    train = op.Cast(train, to=BOOL.dtype)
     rank_input = op.Size(op.Shape(input))
     if rank_input == 0:
         input = op.Reshape(input, op.Constant(value_ints=[-1]))

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -203,24 +203,16 @@ def aten_alpha_dropout(input: TensorType, p: float, train: bool) -> TensorType:
 def aten_amax(self: TReal, dim: INT64, keepdim: bool = False) -> TReal:
     """amax(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor"""
 
-    dim_is_empty = op.Size(dim) == 0
-    if dim_is_empty:
-        result = op.ReduceMax(self, keepdims=keepdim)
-    else:
-        result = op.ReduceMax(self, dim, keepdims=keepdim)
-    return result
+    # ReduceMax reduces all dimensions when dim is empty
+    return op.ReduceMax(self, dim, keepdims=keepdim)
 
 
 @torch_op("aten::amin")
 def aten_amin(self: TReal, dim: INT64, keepdim: bool = False) -> TReal:
     """amin(Tensor self, int[1] dim=[], bool keepdim=False) -> Tensor"""
 
-    dim_is_empty = op.Size(dim) == 0
-    if dim_is_empty:
-        result = op.ReduceMin(self, keepdims=keepdim)
-    else:
-        result = op.ReduceMin(self, dim, keepdims=keepdim)
-    return result
+    # ReduceMin reduces all dimensions when dim is empty
+    return op.ReduceMin(self, dim, keepdims=keepdim)
 
 
 def aten_aminmax(

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -4003,7 +4003,7 @@ def aten_native_group_norm_backward(
 @torch_op("aten::native_layer_norm", trace_only=True)
 def aten_native_layer_norm(
     input: TReal,
-    normalized_shape: INT64,
+    normalized_shape: Sequence[int],
     weight: Optional[TReal],
     bias: Optional[TReal],
     eps: float,
@@ -4015,7 +4015,7 @@ def aten_native_layer_norm(
     # where D is the dimension of normalized_shape. For example, if normalized_shape is
     # (3, 5) (a 2-dimensional shape), the mean and standard-deviation are computed
     # over the last 2 dimensions of the input (i.e. input.mean((-2, -1))).
-    start_axis = op.Neg(op.Size(normalized_shape))
+    start_axis = -len(normalized_shape)
 
     if not op.OptionalHasElement(weight):
         one = op.Constant(value_floats=[1.0])

--- a/onnxscript/tensor.py
+++ b/onnxscript/tensor.py
@@ -63,7 +63,7 @@ class Tensor:
         return float(self.value)
 
     def __len__(self) -> int:
-        return self.rank
+        return len(self.value)
 
     def __index__(self) -> int:
         return self.value.__index__()

--- a/onnxscript/tensor.py
+++ b/onnxscript/tensor.py
@@ -62,6 +62,9 @@ class Tensor:
     def __float__(self) -> float:
         return float(self.value)
 
+    def __len__(self) -> int:
+        return self.rank
+
     def __index__(self) -> int:
         return self.value.__index__()
 

--- a/onnxscript/tensor.py
+++ b/onnxscript/tensor.py
@@ -63,7 +63,7 @@ class Tensor:
         return float(self.value)
 
     def __len__(self) -> int:
-        return len(self.value)
+        return self.shape[0]
 
     def __index__(self) -> int:
         return self.value.__index__()

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -2,9 +2,16 @@
 
 ## How to add a new operator test
 
-1. To enable test cases for an operator, add an entry to the
-`OPINFO_FUNCTION_MAPPING_SCRIPTED` map, run the test and follow instruction in
-error messages if there are any.
+This test use PyTorch's OpInfo mechanism to generate test cases for each operator.
+You may find all OpInfos in https://github.com/pytorch/pytorch/blob/7ec0d6f006fdd2c9b978dc6aa4923144684a3f51/torch/testing/_internal/common_methods_invocations.py#L8804
+
+1. To enable test cases for an operator
+    1a. If the op is not `trace_only`, add an entry to the
+    `OPINFO_FUNCTION_MAPPING_SCRIPTED` map.
+    1b. If the op is `trace_only`, add an entry to the
+    `OPINFO_FUNCTION_MAPPING_TRACE_ONLY` map.
+
+    The entries are <op_info_name: function> pairs.
 2. Edit `EXPECTED_SKIPS_OR_FAILS` and/or `SKIP_SUBTESTS` to skip or xfail tests.
 Prefer xfail over skip when possible.
     2a. If a test is now failing because of xpass, because some previous errors
@@ -1056,7 +1063,7 @@ class TestOutputConsistency(unittest.TestCase):
     This is a parameterized test suite.
     """
 
-    # The function evaluator to use. This is a function that takes a function and its arguments
+    # The function executor to use. This is a function that takes a function and its arguments
     # and returns the output of the function.
     function_executor: Callable
 

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -973,7 +973,9 @@ def _graph_executor(test_class, outputs: Sequence[Any]):
 
         # Disable all ORT optimizations
         session_options = onnxruntime.SessionOptions()
-        session_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
+        session_options.graph_optimization_level = (
+            onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
+        )
         try:
             session = ort.InferenceSession(onnx_model.SerializeToString(), session_options)
             return session.run(None, ort_inputs)

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -512,16 +512,17 @@ OPINFO_FUNCTION_MAPPING: dict[
 TESTED_OPS = frozenset(OPINFO_FUNCTION_MAPPING)
 
 EXPECTED_SKIPS_OR_FAILS = (
-    xfail("logcumsumexp", reason="naive implementation not numerically stable"),
-    xfail("round", variant_name="decimals_0", reason="The op does not support decimals yet", test_class_name="TestOutputConsistency_Eager"),
-    xfail("round", variant_name="decimals_3", reason="The op does not support decimals yet"),
-    xfail("round", variant_name="decimals_neg_3", reason="The op does not support decimals yet"),
     xfail("any", reason="fixme: ORT shape inference error", test_class_name="TestOutputConsistency_FullGraph"),
     xfail("cat", reason="fixme: TorchScriptEvaluator does not support TensorSequence. Enable after #484", test_class_name="TestOutputConsistency_FullGraph"),
     xfail("chunk", reason="fixme: ORT error", test_class_name="TestOutputConsistency_FullGraph"),
     xfail("index_select", reason="fixme: ORT shape inference error on rank-0 input", test_class_name="TestOutputConsistency_FullGraph"),
-    xfail("stack", reason="enable after #484", test_class_name="TestOutputConsistency_FullGraph"),
+    xfail("logcumsumexp", reason="naive implementation not numerically stable"),
+    xfail("round", variant_name="decimals_0", reason="The op does not support decimals yet", test_class_name="TestOutputConsistency_Eager"),
+    xfail("round", variant_name="decimals_3", reason="The op does not support decimals yet"),
+    xfail("round", variant_name="decimals_neg_3", reason="The op does not support decimals yet"),
     xfail("split", reason="fixme: split produces a Sequence type but is set incorrectly in this test", test_class_name="TestOutputConsistency_FullGraph"),
+    xfail("stack", reason="enable after #484", test_class_name="TestOutputConsistency_FullGraph"),
+    xfail("t", reason="ORT Graph attribute inferencing failed on rank-1 input", test_class_name="TestOutputConsistency_FullGraph"),
 )
 
 

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -971,8 +971,11 @@ def _graph_executor(test_class, outputs: Sequence[Any]):
 
         onnx_model = onnxscript_graph.to_model_proto(TEST_OPSET_VERSION)
 
+        # Disable all ORT optimizations
+        session_options = onnxruntime.SessionOptions()
+        session_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
         try:
-            session = ort.InferenceSession(onnx_model.SerializeToString())
+            session = ort.InferenceSession(onnx_model.SerializeToString(), session_options)
             return session.run(None, ort_inputs)
         except (
             onnxruntime.capi.onnxruntime_pybind11_state.Fail,  # pylint: disable=c-extension-no-member

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -516,6 +516,16 @@ EXPECTED_SKIPS_OR_FAILS = (
 
 SKIP_SUBTESTS: tuple[DecorateMeta, ...] = (
     skip(
+        "amax",
+        matcher=lambda sample: len(sample.input.shape) == 0,
+        reason="fixme: ORT aborts on scalar inputs to ReduceMax-18",
+    ),
+    skip(
+        "amin",
+        matcher=lambda sample: len(sample.input.shape) == 0,
+        reason="fixme: ORT aborts on scalar inputs to ReduceMin-18",
+    ),
+    skip(
         "arange",
         matcher=lambda sample: len(sample.args) != 0,
         reason="arange overload takes single argument",

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -18,8 +18,9 @@ Prefer xfail over skip when possible.
     are now fixed, removed the corresponding xfail.
 3. If sample inputs of the OpInfo needs to be adjusted to fit the aten signature, create an input
 wrangler function. See `_cat_input_wrangler` for an example.
-4. If the OpInfo needs to be duplicated to test multiple overloads, use
-`duplicate_opinfo` to create a new OpInfo with a new name.
+4. To test different ONNX functions that are registered as overloads of the same
+    op, use `duplicate_opinfo` to create new OpInfo with new names and map each
+    to one overload.
 """
 from __future__ import annotations
 

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -9,7 +9,7 @@ error messages if there are any.
 Prefer xfail over skip when possible.
     2a. If a test is now failing because of xpass, because some previous errors
     are now fixed, removed the corresponding xfail.
-3. If the OpInfo needs to be adjusted to fit the aten signature, create an input
+3. If sample inputs of the OpInfo needs to be adjusted to fit the aten signature, create an input
 wrangler function. See `_cat_input_wrangler` for an example.
 4. If the OpInfo needs to be duplicated to test multiple overloads, use
 `duplicate_opinfo` to create a new OpInfo with a new name.

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -1,4 +1,17 @@
-"""Test op correctness by comparing with PyTorch results."""
+"""Test op correctness by comparing with PyTorch results.
+
+## How to add a new operator test
+
+1. To enable test cases for an operator, add an entry to the
+`OPINFO_FUNCTION_MAPPING_SCRIPTED` map, run the test and follow instruction in
+error messages if there are any.
+2. Edit `EXPECTED_SKIPS_OR_FAILS` and/or `SKIP_SUBTESTS` to skip or xfail tests.
+Prefer xfail over skip when possible.
+3. If the OpInfo needs to be adjusted to fit the aten signature, create an input
+wrangler function. See `_cat_input_wrangler` for an example.
+4. If the OpInfo needs to be duplicated to test multiple overloads, use
+`duplicate_opinfo` to create a new OpInfo with a new name.
+"""
 from __future__ import annotations
 
 import copy

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -16,9 +16,9 @@ wrangler function. See `_cat_input_wrangler` for an example.
 """
 from __future__ import annotations
 
-import pprint
 import copy
 import dataclasses
+import pprint
 import unittest
 import warnings
 from typing import Any, Callable, Collection, Iterable, Optional, Sequence, TypeVar
@@ -512,17 +512,48 @@ OPINFO_FUNCTION_MAPPING: dict[
 TESTED_OPS = frozenset(OPINFO_FUNCTION_MAPPING)
 
 EXPECTED_SKIPS_OR_FAILS = (
-    xfail("any", reason="fixme: ORT shape inference error", test_class_name="TestOutputConsistency_FullGraph"),
-    xfail("cat", reason="fixme: TorchScriptEvaluator does not support TensorSequence. Enable after #484", test_class_name="TestOutputConsistency_FullGraph"),
-    xfail("chunk", reason="fixme: ORT error", test_class_name="TestOutputConsistency_FullGraph"),
-    xfail("index_select", reason="fixme: ORT shape inference error on rank-0 input", test_class_name="TestOutputConsistency_FullGraph"),
+    xfail(
+        "any",
+        reason="fixme: ORT shape inference error",
+        test_class_name="TestOutputConsistency_FullGraph",
+    ),
+    xfail(
+        "cat",
+        reason="fixme: TorchScriptEvaluator does not support TensorSequence. Enable after #484",
+        test_class_name="TestOutputConsistency_FullGraph",
+    ),
+    xfail(
+        "chunk", reason="fixme: ORT error", test_class_name="TestOutputConsistency_FullGraph"
+    ),
+    xfail(
+        "index_select",
+        reason="fixme: ORT shape inference error on rank-0 input",
+        test_class_name="TestOutputConsistency_FullGraph",
+    ),
     xfail("logcumsumexp", reason="naive implementation not numerically stable"),
-    xfail("round", variant_name="decimals_0", reason="The op does not support decimals yet", test_class_name="TestOutputConsistency_Eager"),
+    xfail(
+        "round",
+        variant_name="decimals_0",
+        reason="The op does not support decimals yet",
+        test_class_name="TestOutputConsistency_Eager",
+    ),
     xfail("round", variant_name="decimals_3", reason="The op does not support decimals yet"),
-    xfail("round", variant_name="decimals_neg_3", reason="The op does not support decimals yet"),
-    xfail("split", reason="fixme: split produces a Sequence type but is set incorrectly in this test", test_class_name="TestOutputConsistency_FullGraph"),
-    xfail("stack", reason="enable after #484", test_class_name="TestOutputConsistency_FullGraph"),
-    xfail("t", reason="ORT Graph attribute inferencing failed on rank-1 input", test_class_name="TestOutputConsistency_FullGraph"),
+    xfail(
+        "round", variant_name="decimals_neg_3", reason="The op does not support decimals yet"
+    ),
+    xfail(
+        "split",
+        reason="fixme: split produces a Sequence type but is set incorrectly in this test",
+        test_class_name="TestOutputConsistency_FullGraph",
+    ),
+    xfail(
+        "stack", reason="enable after #484", test_class_name="TestOutputConsistency_FullGraph"
+    ),
+    xfail(
+        "t",
+        reason="ORT Graph attribute inferencing failed on rank-1 input",
+        test_class_name="TestOutputConsistency_FullGraph",
+    ),
 )
 
 

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -876,12 +876,6 @@ def _graph_executor(test_class, outputs: Sequence[Any]):
         onnxscript_args: list[Any] = []
         onnxscript_kwargs = {}
         for i, arg in enumerate(args):
-            if arg is None and isinstance(function, onnxscript.OnnxFunction):
-                # For optional inputs, if the function is an OnnxFunction, we
-                # need to skip the input to create a static optional in the ONNX graph.
-                # If the function is a python function, we need to pass in None
-                # to avoid a TypeError.
-                continue
             if isinstance(arg, np.ndarray):
                 input_name = f"input_{i}"
                 input = onnxscript_graph.add_input(input_name, torch.tensor(arg))
@@ -901,12 +895,6 @@ def _graph_executor(test_class, outputs: Sequence[Any]):
             else:
                 onnxscript_args.append(arg)
         for key, value in kwargs.items():
-            if value is None and isinstance(function, onnxscript.OnnxFunction):
-                # For optional inputs, if the function is an OnnxFunction, we
-                # need to skip the input to create a static optional in the ONNX graph.
-                # If the function is a python function, we need to pass in None
-                # to avoid a TypeError.
-                continue
             if isinstance(value, np.ndarray):
                 input = onnxscript_graph.add_input(key, torch.tensor(value))
                 input.value = value

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -7,6 +7,8 @@
 error messages if there are any.
 2. Edit `EXPECTED_SKIPS_OR_FAILS` and/or `SKIP_SUBTESTS` to skip or xfail tests.
 Prefer xfail over skip when possible.
+    2a. If a test is now failing because of xpass, because some previous errors
+    are now fixed, removed the corresponding xfail.
 3. If the OpInfo needs to be adjusted to fit the aten signature, create an input
 wrangler function. See `_cat_input_wrangler` for an example.
 4. If the OpInfo needs to be duplicated to test multiple overloads, use
@@ -986,7 +988,9 @@ class TestOutputConsistency(unittest.TestCase):
                             check_device=False,
                         )
                     except AssertionError as e:
-                        raise AssertionError(f"Output {j} mismatch") from e
+                        if len(flattened_torch_outputs) > 1:
+                            raise AssertionError(f"Output {j} mismatch") from e
+                        raise
 
 
 # The name needs to match the parameterized_class name.

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -680,13 +680,20 @@ def _should_skip_test_sample(op_name: str, sample) -> Optional[str]:
     return None
 
 
+
+
 class TestFunctionValidity(unittest.TestCase):
     def test_all_script_functions_are_onnx_functions(self):
+        functions = set()
         for func_with_wrangler in OPINFO_FUNCTION_MAPPING_SCRIPTED.values():
             if isinstance(func_with_wrangler, tuple):
                 func = func_with_wrangler[0]
             else:
                 func = func_with_wrangler
+            functions.add(func)
+
+        # TODO(justinchuby): Add from the registry
+        for func in functions:
             if not isinstance(func, onnxscript.OnnxFunction):
                 raise AssertionError(
                     f"'{func}' is not an OnnxFunction. Was it decorated with '@torch_op'? "
@@ -720,7 +727,10 @@ class TestFunctionValidity(unittest.TestCase):
         function_proto = func.to_function_proto()
         onnx.checker.check_function(function_proto)  # type: ignore[attr-defined]
 
+# TODO: create an evaluator that captures the full graph and then compute using
+# the full graph. This will be useful for testing the full graph.
 
+# TODO(justinchuby): Parameterize this and construct different backends
 class TestOutputConsistency(unittest.TestCase):
     """Test output consistency between exported ONNX models and PyTorch eager mode.
 

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -563,6 +563,12 @@ EXPECTED_SKIPS_OR_FAILS = (
         test_class_name="TestOutputConsistency_FullGraph",
     ),
     xfail(
+        "min_dim",
+        variant_name="reduction_with_dim",
+        reason="ORT Graph attribute inferencing failed https://github.com/onnx/onnx/issues/4986",
+        test_class_name="TestOutputConsistency_FullGraph",
+    ),
+    xfail(
         "new_full",
         reason="fixme: ORT fails with invalid model: 'ONNX Schema aten_new_full: failed validating the check: !(it.GetName().empty())'",
         test_class_name="TestOutputConsistency_FullGraph",

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -16,6 +16,7 @@ wrangler function. See `_cat_input_wrangler` for an example.
 """
 from __future__ import annotations
 
+import pprint
 import copy
 import dataclasses
 import unittest
@@ -512,14 +513,15 @@ TESTED_OPS = frozenset(OPINFO_FUNCTION_MAPPING)
 
 EXPECTED_SKIPS_OR_FAILS = (
     xfail("logcumsumexp", reason="naive implementation not numerically stable"),
-    xfail("round", variant_name="decimals_0", reason="The op does not support decimals"),
-    xfail("round", variant_name="decimals_3", reason="The op does not support decimals"),
-    xfail("round", variant_name="decimals_neg_3", reason="The op does not support decimals"),
+    xfail("round", variant_name="decimals_0", reason="The op does not support decimals yet", test_class_name="TestOutputConsistency_Eager"),
+    xfail("round", variant_name="decimals_3", reason="The op does not support decimals yet"),
+    xfail("round", variant_name="decimals_neg_3", reason="The op does not support decimals yet"),
     xfail("any", reason="fixme: ORT shape inference error", test_class_name="TestOutputConsistency_FullGraph"),
     xfail("cat", reason="fixme: TorchScriptEvaluator does not support TensorSequence. Enable after #484", test_class_name="TestOutputConsistency_FullGraph"),
     xfail("chunk", reason="fixme: ORT error", test_class_name="TestOutputConsistency_FullGraph"),
     xfail("index_select", reason="fixme: ORT shape inference error on rank-0 input", test_class_name="TestOutputConsistency_FullGraph"),
-    xfail("chunk", reason="fixme: ORT error", test_class_name="TestOutputConsistency_FullGraph"),
+    xfail("stack", reason="enable after #484", test_class_name="TestOutputConsistency_FullGraph"),
+    xfail("split", reason="fixme: split produces a Sequence type but is set incorrectly in this test", test_class_name="TestOutputConsistency_FullGraph"),
 )
 
 
@@ -844,7 +846,8 @@ def _graph_executor(test_class, outputs: Sequence[Any]):
         ) as e:
             raise AssertionError(
                 f"ONNX Runtime failed to evaluate:\n"
-                f"Inputs: {ort_inputs}\n"
+                f"Inputs:\n"
+                f"{pprint.pformat(ort_inputs)}\n"
                 f"Model:\n"
                 f"{onnxscript.proto2text(onnx_model)}"
             ) from e

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -607,6 +607,11 @@ EXPECTED_SKIPS_OR_FAILS = (
         test_class_name="TestOutputConsistency_FullGraph",
     ),
     xfail(
+        "split_with_sizes",
+        reason="fixme: split produces a Sequence type but is set incorrectly in this test",
+        test_class_name="TestOutputConsistency_FullGraph",
+    ),
+    xfail(
         "stack", reason="enable after #484", test_class_name="TestOutputConsistency_FullGraph"
     ),
     xfail(

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -873,7 +873,7 @@ def _graph_executor(test_class, outputs: Sequence[Any]):
         onnxscript_graph = graph_building.TorchScriptGraph()
         tracer = graph_building.TorchScriptTracingEvaluator(onnxscript_graph)
         ort_inputs = {}
-        onnxscript_args = []
+        onnxscript_args: list[Any] = []
         onnxscript_kwargs = {}
         for i, arg in enumerate(args):
             if arg is None and isinstance(function, onnxscript.OnnxFunction):

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -795,7 +795,7 @@ def _graph_executor(test_class, outputs: Sequence[Any]):
             if isinstance(arg, np.ndarray):
                 input_name = f"input_{i}"
                 input = onnxscript_graph.add_input(input_name, torch.tensor(arg))
-                input.shape = arg.shape
+                input.value = arg
                 onnxscript_args.append(input)
                 ort_inputs[input_name] = arg
             elif isinstance(arg, Sequence):
@@ -804,7 +804,7 @@ def _graph_executor(test_class, outputs: Sequence[Any]):
                     if isinstance(subarg, np.ndarray):
                         input_name = f"input_{i}_{j}"
                         input = onnxscript_graph.add_input(input_name, torch.tensor(subarg))
-                        input.shape = subarg.shape
+                        input.value = subarg
                         sequence_input.append(input)
                         ort_inputs[input_name] = subarg
                 onnxscript_args.append(sequence_input)
@@ -813,7 +813,7 @@ def _graph_executor(test_class, outputs: Sequence[Any]):
         for key, value in kwargs.items():
             if isinstance(value, np.ndarray):
                 input = onnxscript_graph.add_input(key, torch.tensor(value))
-                input.shape = value.shape
+                input.value = value
                 ort_inputs[key] = value
                 onnxscript_kwargs[key] = input
             else:

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -86,6 +86,9 @@ class DecorateMeta:
     reason: str
     matcher: Optional[Callable[[Any], bool]] = None
     enabled_if: bool = True
+    # The test_class_name to apply the decorator to. If None, the decorator is
+    # applied to all test classes.
+    test_class_name: Optional[str] = None
 
 
 def xfail(
@@ -95,6 +98,7 @@ def xfail(
     reason: str,
     dtypes: Optional[Collection[torch.dtype]] = None,
     enabled_if: bool = True,
+    test_class_name: Optional[str] = None,
 ) -> DecorateMeta:
     """Expects an OpInfo test to fail.
 
@@ -104,6 +108,8 @@ def xfail(
         reason: The reason for the failure.
         dtypes: The dtypes to expect the failure.
         enabled_if: Whether the xfail is enabled.
+        test_class_name: The test class name to apply the xfail to. If None, the
+            xfail is applied to all test classes.
     """
     return DecorateMeta(
         op_name=op_name,
@@ -112,6 +118,7 @@ def xfail(
         dtypes=dtypes,
         reason=reason,
         enabled_if=enabled_if,
+        test_class_name=test_class_name,
     )
 
 
@@ -123,6 +130,7 @@ def skip(
     dtypes: Optional[Collection[torch.dtype]] = None,
     matcher: Optional[Callable[[Any], Any]] = None,
     enabled_if: bool = True,
+    test_class_name: Optional[str] = None,
 ) -> DecorateMeta:
     """Skips an OpInfo test.
 
@@ -134,6 +142,8 @@ def skip(
         matcher: A function that matches the test sample input. It is used only when
             the skip is in the SKIP_SUBTESTS list.
         enabled_if: Whether the skip is enabled.
+        test_class_name: The test class name to apply the skip to. If None, the skip
+            is applied to all test classes.
     """
     return DecorateMeta(
         op_name=op_name,
@@ -143,6 +153,7 @@ def skip(
         reason=reason,
         matcher=matcher,
         enabled_if=enabled_if,
+        test_class_name=test_class_name,
     )
 
 
@@ -162,7 +173,7 @@ def add_decorate_info(
         decorators = list(opinfo.decorators)
         new_decorator = opinfo_core.DecorateInfo(
             decorate_meta.decorator,
-            test_class_name,
+            decorate_meta.test_class_name or test_class_name,
             base_test_name,
             dtypes=decorate_meta.dtypes,
             active_if=decorate_meta.enabled_if,
@@ -513,6 +524,11 @@ EXPECTED_SKIPS_OR_FAILS = (
     xfail("round", variant_name="decimals_0", reason="The op does not support decimals"),
     xfail("round", variant_name="decimals_3", reason="The op does not support decimals"),
     xfail("round", variant_name="decimals_neg_3", reason="The op does not support decimals"),
+    xfail("any", reason="fixme: ORT shape inference error", test_class_name="TestOutputConsistency_FullGraph"),
+    xfail("cat", reason="fixme: TorchScriptEvaluator does not support TensorSequence. Enable after #484", test_class_name="TestOutputConsistency_FullGraph"),
+    xfail("chunk", reason="fixme: ORT error", test_class_name="TestOutputConsistency_FullGraph"),
+    xfail("index_select", reason="fixme: ORT shape inference error on rank-0 input", test_class_name="TestOutputConsistency_FullGraph"),
+    xfail("chunk", reason="fixme: ORT error", test_class_name="TestOutputConsistency_FullGraph"),
 )
 
 


### PR DESCRIPTION
Test TorchScriptEvaluator by capturing function protos and the full graph and executing the model with ORT. Only runs on torch-nightly.

Parameterize the TestOpConsistency body to run in both eager mode and graph mode.

Fix
- Remove opset17 reference
- amin
- amax
- native_layer_norm
- dropout

`OptionalGetElement` is not mature enough to use right now. We need to fix shape inference to use it.

Others are marked as xfail for now to fix in future PRs.