### PR TITLE
feat(atenlib): create a `private` tag for private functions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Run lintrunner on all files
         run: |
           set +e
-          if ! lintrunner --force-color --all-files --tee-json=lint.json -v; then
+          if ! lintrunner --force-color --all-files --tee-json=lint.json -v --skip MYPY; then
               echo ""
               echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner -m main\`.\e[0m"
               exit 1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Run lintrunner on all files
         run: |
           set +e
-          if ! lintrunner --force-color --all-files --tee-json=lint.json; then
+          if ! lintrunner --force-color --all-files --tee-json=lint.json -v; then
               echo ""
               echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner -m main\`.\e[0m"
               exit 1

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -98,7 +98,7 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'mypy==1.0.0',
+    'mypy==1.1.1',
     'types-PyYAML==6.0.12.4',
 ]
 

--- a/onnxscript/function_libs/torch_aten/ops/core.py
+++ b/onnxscript/function_libs/torch_aten/ops/core.py
@@ -1362,7 +1362,7 @@ def aten_convolution(
     return result
 
 
-@torch_op("aten::convolution", overload=True)
+@torch_op("aten::convolution", private=True)
 def _aten_convolution_onnx(
     input: TFloat,
     weight: TFloat,
@@ -1767,7 +1767,7 @@ def aten_cumsum(
     return _aten_cumsum_onnx(cast, dim)
 
 
-@torch_op("aten::cumsum", overload=True)
+@torch_op("aten::cumsum", private=True)
 def _aten_cumsum_onnx(
     self: TRealUnlessInt16OrInt8, dim: Union[INT32, INT64]
 ) -> TRealUnlessInt16OrInt8:
@@ -2033,7 +2033,7 @@ def aten_empty_like(self: TTensor, dtype: int = -1) -> TTensor:
     return _aten_empty_like_onnx(self, zero)
 
 
-@torch_op("aten::empty_like", overload=True)
+@torch_op("aten::empty_like", private=True)
 def _aten_empty_like_onnx(self: TTensor, zero) -> TTensor:
     shape = op.Shape(self)
     return op.Expand(zero, shape)
@@ -2722,7 +2722,7 @@ def aten_index_select(self: TTensor, dim: int, index: IntType) -> TTensor:
     return _aten_index_select_onnx(self, index, dim=dim)
 
 
-@torch_op("aten::index_select", overload=True)
+@torch_op("aten::index_select", private=True)
 def _aten_index_select_onnx(self: TTensor, index: IntType, dim: int) -> TTensor:
     """index_select(Tensor self, int dim, Tensor index) -> Tensor"""
 
@@ -3003,7 +3003,7 @@ def aten_layer_norm(
     return _aten_layer_norm_onnx(input, weight, bias, axis=start_axis, eps=eps)
 
 
-@torch_op("aten::layer_norm", overload=True)
+@torch_op("aten::layer_norm", private=True)
 def _aten_layer_norm_onnx(
     input: TReal,
     weight: TReal,
@@ -3402,20 +3402,19 @@ def aten_max(
     return result
 
 
-@torch_op("aten::max", overload=True)
+@torch_op("aten::max", private=True)
 def _aten_max_with_no_dim(self: TReal) -> TReal:
     result = op.ReduceMax(self, keepdims=0)
     return result
 
 
-@torch_op("aten::max", overload=True)
+@torch_op("aten::max", private=True)
 def _aten_max_with_other(self: TReal, other: TReal) -> TReal:
     result = op.Max(self, other)
     return result
 
 
-@torch_op("aten::max", overload=True)
-# def _aten_max_with_dim(self: TReal, dim: int, keepdim: bool) -> tuple[TReal, TInt]:
+@torch_op("aten::max", private=True)
 def _aten_max_with_dim(self: TReal, dim: int, keepdim: bool):
     dims = op.Reshape(dim, op.Constant(value_int=[-1]))
     result = op.ReduceMax(self, dims, keepdims=keepdim)
@@ -4291,7 +4290,7 @@ def aten_ones_like(self: TTensor, dtype: int = -1) -> TTensor:
     return _aten_ones_like_onnx(self, one)
 
 
-@torch_op("aten::ones_like", overload=True)
+@torch_op("aten::ones_like", private=True)
 def _aten_ones_like_onnx(self: TTensor, one) -> TTensor:
     shape = op.Shape(self)
     return op.Expand(one, shape)
@@ -5321,7 +5320,7 @@ def aten_sum_dim_IntList(
     return result
 
 
-@torch_op("aten::sum", overload=True)
+@torch_op("aten::sum", private=True)
 def _aten_sum_dim_onnx(self: TReal, dim: INT64, keepdim: bool = False) -> TReal:
     self_is_scalar = op.Size(op.Shape(self)) == 0
     if self_is_scalar:
@@ -5337,7 +5336,7 @@ def _aten_sum_dim_onnx(self: TReal, dim: INT64, keepdim: bool = False) -> TReal:
     return result
 
 
-@torch_op("aten::sum", overload=True)
+@torch_op("aten::sum", private=True)
 def _aten_sum_dim_none(self: TReal, keepdim: bool = False) -> TReal:
     self_is_scalar = op.Size(op.Shape(self)) == 0
     if self_is_scalar:
@@ -5863,7 +5862,7 @@ def aten_zeros_like(self: TTensor, dtype: int = -1) -> TTensor:
     return _aten_zeros_like_onnx(self, zero)
 
 
-@torch_op("aten::zeros_like", overload=True)
+@torch_op("aten::zeros_like", private=True)
 def _aten_zeros_like_onnx(self: TTensor, zero) -> TTensor:
     shape = op.Shape(self)
     return op.Expand(zero, shape)

--- a/onnxscript/function_libs/torch_aten/ops/nn.py
+++ b/onnxscript/function_libs/torch_aten/ops/nn.py
@@ -260,7 +260,7 @@ def aten_cross_entropy_loss(
     return result
 
 
-@torch_op("aten::cross_entropy_loss", overload=True)
+@torch_op("aten::cross_entropy_loss", private=True)
 def _aten_cross_entropy_loss_onnx(
     self: TFloatOrBFloat16,
     target: Sequence[int],
@@ -372,7 +372,7 @@ def aten_gelu(self: TReal, approximate: str = "none") -> TReal:
     return result
 
 
-@torch_op("aten::gelu", overload=True)
+@torch_op("aten::gelu", private=True)
 def _aten_gelu_approximate_none(self: TReal) -> TReal:
     """gelu(Tensor self, *, str approximate='none') -> Tensor"""
 
@@ -386,7 +386,7 @@ def _aten_gelu_approximate_none(self: TReal) -> TReal:
     return result
 
 
-@torch_op("aten::gelu", overload=True)
+@torch_op("aten::gelu", private=True)
 def _aten_gelu_approximate_tanh(self: TReal) -> TReal:
     """gelu(Tensor self, *, str approximate='none') -> Tensor"""
 
@@ -1300,7 +1300,7 @@ def aten_upsample_nearest2d(
     return _aten_upsample_nearest2d_onnx(self, size)
 
 
-@torch_op("aten::upsample_nearest2d", overload=True)
+@torch_op("aten::upsample_nearest2d", private=True)
 def _aten_upsample_nearest2d_onnx(
     self: TReal,
     size: INT64,

--- a/onnxscript/function_libs/torch_aten/registration.py
+++ b/onnxscript/function_libs/torch_aten/registration.py
@@ -30,7 +30,9 @@ class Registry:
     def __init__(self):
         self._registry: dict[str, OverloadedFunction] = {}
 
-    def register(self, func: Any, name: str, *, overload: bool = False, private: bool = False) -> None:
+    def register(
+        self, func: Any, name: str, *, overload: bool = False, private: bool = False
+    ) -> None:
         """Register a function."""
 
         if overload:
@@ -79,7 +81,6 @@ def torch_op(
         registry = default_registry
 
     def wrapper(func: Callable[..., Any]) -> onnxscript.OnnxFunction | Callable[..., Any]:
-
         if trace_only:
             processed_func = func
         else:

--- a/onnxscript/function_libs/torch_aten/registration.py
+++ b/onnxscript/function_libs/torch_aten/registration.py
@@ -8,12 +8,20 @@ import onnxscript
 
 
 class OverloadedFunction:
-    """Overloaded function."""
+    """Overloaded function.
+
+    Attributes:
+        name: Name of the op. E.g. "aten::add".
+        default: Default function.
+        overloads: Overloads.
+        privates: Private functions not exposed to users.
+    """
 
     def __init__(self, name: str):
         self.name = name
         self.default: Optional[Any] = None
         self.overloads: list[Any] = []
+        self.privates: list[Any] = []
 
 
 class Registry:
@@ -22,11 +30,13 @@ class Registry:
     def __init__(self):
         self._registry: dict[str, OverloadedFunction] = {}
 
-    def register(self, func: Any, name: str, *, overload: bool = False) -> None:
+    def register(self, func: Any, name: str, *, overload: bool = False, private: bool = False) -> None:
         """Register a function."""
 
         if overload:
             self._registry.setdefault(name, OverloadedFunction(name)).overloads.append(func)
+        elif private:
+            self._registry.setdefault(name, OverloadedFunction(name)).privates.append(func)
         else:
             self._registry.setdefault(name, OverloadedFunction(name)).default = func
 
@@ -53,6 +63,7 @@ def torch_op(
     overload: bool = False,
     registry: Optional[Registry] = None,
     trace_only: bool = False,
+    private: bool = False,
 ) -> Callable[[Callable[..., Any]], onnxscript.OnnxFunction | Callable[..., Any]]:
     """Register a torch op.
 
@@ -61,6 +72,8 @@ def torch_op(
         overload: Whether the function is an overload (not default).
         registry: Registry to register the function to. If None, the default registry is used.
         trace_only: Whether the function should only be traced and not compiled.
+        private: Whether the function is private (not directly exposed). It should
+            be true for all functions with names starting with "_".
     """
     if registry is None:
         registry = default_registry
@@ -75,7 +88,7 @@ def torch_op(
             processed_func = onnxscript.script(opset=custom_opset)(func)
 
         assert registry is not None
-        registry.register(processed_func, name, overload=overload)
+        registry.register(processed_func, name, overload=overload, private=private)
         return processed_func
 
     return wrapper


### PR DESCRIPTION
Currently private functions are marked as `overload`s. Since private functions (anything starts with `_`) will never be dispatched onto by the exporter, we can create a new label `private` to register them differently.

Fixes https://github.com/microsoft/onnx-script/issues/504