### PR TITLE
fix(atenlib): test split and support Sequence input

### DIFF
--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -397,7 +397,7 @@ class TorchScriptGraph:
         graph_inputs = []
         assert isinstance(unwrapped_inputs, Sequence)
         for input in unwrapped_inputs:
-            if isinstance(input, Sequence) and any(
+            if isinstance(input, Sequence) and all(
                 isinstance(elem, torch.Value) for elem in input
             ):
                 input_sequence = _create_op_call_in_torch_graph(

--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -397,7 +397,17 @@ class TorchScriptGraph:
         graph_inputs = []
         assert isinstance(unwrapped_inputs, Sequence)
         for input in unwrapped_inputs:
-            if not isinstance(input, torch.Value):
+            if isinstance(input, Sequence) and any(
+                isinstance(elem, torch.Value) for elem in input
+            ):
+                input_sequence = _create_op_call_in_torch_graph(
+                    self._torch_graph,
+                    "onnx::SequenceConstruct",
+                    inputs=input,
+                    attributes={},
+                )[0]
+                graph_inputs.append(input_sequence)
+            elif not isinstance(input, torch.Value):
                 graph_inputs.append(self._add_constant_to_graph(input))
             else:
                 graph_inputs.append(input)

--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -400,6 +400,8 @@ class TorchScriptGraph:
             if isinstance(input, Sequence) and all(
                 isinstance(elem, torch.Value) for elem in input
             ):
+                # If all elements in the Sequence are torch.Values we know it
+                # should be a Sequence input in ONNX.
                 input_sequence = _create_op_call_in_torch_graph(
                     self._torch_graph,
                     "onnx::SequenceConstruct",

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -558,11 +558,6 @@ EXPECTED_SKIPS_OR_FAILS = (
         test_class_name="TestOutputConsistency_FullGraph",
     ),
     xfail(
-        "cat",
-        reason="fixme: TorchScriptEvaluator does not support TensorSequence. Enable after #484",
-        test_class_name="TestOutputConsistency_FullGraph",
-    ),
-    xfail(
         "chunk", reason="fixme: ORT error", test_class_name="TestOutputConsistency_FullGraph"
     ),
     xfail(
@@ -623,9 +618,6 @@ EXPECTED_SKIPS_OR_FAILS = (
     xfail("round", variant_name="decimals_3", reason="The op does not support decimals yet"),
     xfail(
         "round", variant_name="decimals_neg_3", reason="The op does not support decimals yet"
-    ),
-    xfail(
-        "stack", reason="enable after #484", test_class_name="TestOutputConsistency_FullGraph"
     ),
     xfail(
         "t",

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -987,7 +987,7 @@ def _graph_executor(test_class, outputs: Sequence[Any]):
 
         with onnxscript.evaluator.default_as(tracer):
             symbolic_outputs = function(*onnxscript_args, **onnxscript_kwargs)
-        if not isinstance(symbolic_outputs, tuple):
+        if not isinstance(symbolic_outputs, Sequence):
             symbolic_outputs = (symbolic_outputs,)
 
         # We need to set the size of the output tensors for the ONNX model to be valid


### PR DESCRIPTION
This PR adjusts the test code to be able to handle the output of `torch.split` and adds support for sequence as input. Note that this is different from the exporter's concat for symints, because at the point when we have inputs processed and still get list of Tensors as a single argument, we know it should be an ONNX Sequence tensor in the graph.

We also need to keep the addition in here and not in the exporter to match behavior with onnxscript eager: we accept a list of tensors as input when the op takes a Sequence.