### PR TITLE
fix(graph_building): change `add_initializer` to return a Tensor; make shape inference optional

### DIFF
--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -472,7 +472,7 @@ class TorchScriptGraph:
         return result
 
     @beartype
-    def to_model_proto(self, opset_version: int, run_onnx_shape_inference: bool = True) -> onnx.ModelProto:
+    def to_model_proto(self, opset_version: int) -> onnx.ModelProto:
         (
             proto,
             _,
@@ -498,11 +498,11 @@ class TorchScriptGraph:
         for onnx_function in self._function_store.values():
             function_proto_list.append(onnx_function.to_function_proto())
         onnx_model.functions.extend(function_proto_list)
-        if run_onnx_shape_inference:
+
+        try:
             onnx_model = onnx.shape_inference.infer_shapes(
                 onnx_model, check_type=True, strict_mode=False, data_prop=True
             )
-        try:
             onnx.checker.check_model(onnx_model, full_check=True)
         except (onnx.checker.ValidationError, onnx.shape_inference.InferenceError) as e:
             warnings.warn(f"ONNX model is invalid: {e}")

--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -333,8 +333,13 @@ class TorchScriptGraph:
 
     @beartype
     def add_initializer(self, input_name: str, input_value: torch.Tensor) -> TorchScriptTensor:
+        if input_name in self._initializers:
+            raise ValueError(f"Initializer {input_name} exists already")
         self._initializers[input_name] = input_value
-        return self.add_input(input_name, input_value)
+        torch_value = self._torch_graph.addInput(input_name)
+        torch_value.setType(torch.TensorType.create_from_tensor(input_value))
+        tensor_value = _wrap_torch_value_to_tensor(torch_value)
+        return tensor_value
 
     @beartype
     def register_outputs(

--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -332,12 +332,12 @@ class TorchScriptGraph:
         return tensor_value  # type: ignore[return-value]
 
     @beartype
-    def add_initializer(self, input_name: str, input_value: torch.Tensor) -> TorchScriptTensor:
-        if input_name in self._initializers:
-            raise ValueError(f"Initializer {input_name} exists already")
-        self._initializers[input_name] = input_value
-        torch_value = self._torch_graph.addInput(input_name)
-        torch_value.setType(torch.TensorType.create_from_tensor(input_value))
+    def add_initializer(self, name: str, value: torch.Tensor) -> TorchScriptTensor:
+        if name in self._initializers:
+            raise ValueError(f"Initializer '{name}' exists already")
+        self._initializers[name] = value
+        torch_value = self._torch_graph.addInput(name)
+        torch_value.setType(torch.TensorType.create_from_tensor(value))
         tensor_value = _wrap_torch_value_to_tensor(torch_value)
         return tensor_value
 

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -1019,6 +1019,8 @@ def _graph_executor(
         onnxscript_graph.register_outputs(symbolic_outputs)
 
         onnx_model = onnxscript_graph.to_model_proto(TEST_OPSET_VERSION)
+        # Make sure the model is valid
+        onnx.checker.check_model(onnx_model, full_check=True)
 
         # Disable all ORT optimizations
         session_options = onnxruntime.SessionOptions()


### PR DESCRIPTION
1. Initializer must be an input. Otherwise, there is no torch._C.Value to repreent it in torch._C.Graph.
2. Shape inference fails for custom op, so it should be optional until we fix it.