### PR TITLE
chore(ci): use PyTorch 2.0

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,7 @@ COMMON_TEST_DEPENDENCIES = (
 )
 ONNX = "onnx==1.13.1"
 ONNX_RUNTIME = "onnxruntime==1.14.1"
-PYTORCH = "torch==1.13.1"
+PYTORCH = "torch==2.0.0"
 
 
 @nox.session(tags=["build"])

--- a/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
+++ b/onnxscript/tests/function_libs/torch_aten/ops_correctness_test.py
@@ -285,15 +285,6 @@ def _empty_input_wrangler(
     return args, kwargs
 
 
-def _full_input_wrangler(
-    args: list[Any], kwargs: dict[str, Any]
-) -> tuple[list[Any], dict[str, Any]]:
-    # Remove the self argument
-    if version_utils.torch_older_than("2.0"):
-        args.pop(0)
-    return args, kwargs
-
-
 def _nll_loss_input_wrangler(
     args: list[Any], kwargs: dict[str, Any]
 ) -> tuple[list[Any], dict[str, Any]]:
@@ -400,7 +391,7 @@ OPINFO_FUNCTION_MAPPING_SCRIPTED: dict[
     "erf": core_ops.aten_erf,
     "fill": core_ops.aten_fill,
     "fmod": core_ops.aten_fmod,
-    "full": (core_ops.aten_full, _full_input_wrangler),
+    "full": core_ops.aten_full,
     "full_like": core_ops.aten_full_like,
     "ge": core_ops.aten_ge,
     "gt": core_ops.aten_gt,
@@ -837,8 +828,6 @@ duplicate_opinfo(
     ),
 )
 
-duplicate_opinfo(OPS_DB, "new_full", ("full",))
-
 duplicate_opinfo(OPS_DB, "squeeze", ("squeeze_dim",))
 
 
@@ -1235,9 +1224,6 @@ class TestOutputConsistencyFullGraph(unittest.TestCase):
     @common_device_type.ops(  # type: ignore[misc]
         [info for info in OPS_DB if info.name in TESTED_OPS],
         allowed_dtypes=TESTED_DTYPES,
-    )
-    @unittest.skipIf(
-        version_utils.torch_older_than("2.0"), reason="only torch>=2.0 is supported"
     )
     def test_output_match_opinfo_(
         self, device: str, dtype: torch.dtype, op: opinfo_core.OpInfo


### PR DESCRIPTION
Use PyTorch 2.0 to run tests. Bump aten lib minimal pytorch version to 2.0