### PR TITLE
Type annotate 'all_opsets'

### DIFF
--- a/onnxscript/onnx_opset/__init__.py
+++ b/onnxscript/onnx_opset/__init__.py
@@ -10,6 +10,8 @@
 # pylint: disable=W0221,W0222,W0237,W0246,R0901,W0611
 # --------------------------------------------------------------------------
 
+from typing import Mapping, Tuple
+
 from onnx.defs import onnx_opset_version
 
 from onnxscript.onnx_opset._impl.opset1 import Opset1
@@ -37,6 +39,7 @@ from onnxscript.onnx_opset._impl.opset_ai_onnx_ml3 import Opset_ai_onnx_ml3
 from onnxscript.onnx_opset._impl.opset_ai_onnx_preview_training1 import (
     Opset_ai_onnx_preview_training1,
 )
+from onnxscript.values import Opset
 
 __all__ = [
     "default_opset",
@@ -96,7 +99,7 @@ opset_ai_onnx_ml1 = Opset_ai_onnx_ml1()
 opset_ai_onnx_ml2 = Opset_ai_onnx_ml2()
 opset_ai_onnx_ml3 = Opset_ai_onnx_ml3()
 opset_ai_onnx_preview_training1 = Opset_ai_onnx_preview_training1()
-all_opsets = {
+all_opsets: Mapping[Tuple[str, int], Opset] = {
     (
         "",
         1,

--- a/opgen/onnx_opset_builder.py
+++ b/opgen/onnx_opset_builder.py
@@ -224,7 +224,14 @@ class OpsetsBuilder:
                 init_module.append_body(
                     cg.Assign(cg.Name(opset_export_name), cg.Call(opset_class.make_typeref()))
                 )
-        init_module.append_body(cg.Assign(cg.Name("all_opsets"), all_opsets))
+        all_opsets_type = cg.TypeRef.make_composite_if_multiple(
+            cg.TypingRefs.Mapping,
+            cg.TypeRef.make_composite_if_multiple(
+                cg.TypingRefs.Tuple, cg.StrTypeRef(), cg.IntTypeRef()
+            ),
+            cg.TypeRef(MODULE_ONNX_SCRIPT_VALUES, "Opset"),
+        )
+        init_module.append_body(cg.Assign(cg.Name("all_opsets"), all_opsets, all_opsets_type))
 
         default_opset = cg.Assign(
             cg.Name("default_opset"),


### PR DESCRIPTION
Otherwise pylance/intellisense shows inferred type `dict[tuple[Literal[''], Literal[1]] | tuple[Literal[''], Literal[2]] | tuple[Literal[''], Literal[3]] | tuple[Literal[''], Literal[4]] | tuple[Literal[''], Literal[5]] | tuple[Literal[''], Literal[6]] | tuple[Literal[''], Literal[7]] | tuple[Literal[''], Literal[8]] | tuple[Literal[''], Literal[9]] | tuple[Literal[''], Literal[10]] | tuple[Literal[''], Literal[11]] | tuple[Literal[''], Literal[12]] | tuple[Literal[''], Literal[13]] | tuple[Literal[''], Literal[14]] | tuple[Literal[''], Literal[15]] | tuple[Literal[''], Literal[16]] | tuple[Literal[''], Literal[17]] | tuple[Literal[''], Literal[18]] | tuple[Literal[''], Literal[19]] | tuple[Literal['ai.onnx.ml'], Literal[1]] | tuple[Literal['ai.onnx.ml'], Literal[2]] | tuple[Literal['ai.onnx.ml'], Literal[3]] | tuple[Literal['ai.onnx.preview.training'], Literal[1]], Unknown]`

@abock 