### PR TITLE
Specify setuptools version | chore(release)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-
 [build-system]
 requires = ["setuptools>=61.0.0"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=61.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,14 @@
 click
 numpy
-matplotlib
 onnx-weekly
+setuptools>=61.0.0
 --pre -f https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime-function-experiment.html
 ort-function-experiment-nightly
 typing_extensions
 
 # Docs site
 furo
+matplotlib
 sphinx-copybutton
 sphinx-gallery
 sphinx>=6


### PR DESCRIPTION
setuptools needs to be >= 61.0.0 to understand pyproject. Making this clear in requirements.