### PR TITLE
Remove click as a requirement | chore(release)

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,6 @@ nox.options.error_on_missing_interpreters = False
 
 
 COMMON_TEST_DEPENDENCIES = (
-    "click",
     "jinja2",
     "numpy==1.23.5",
     "typing_extensions",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-click
 numpy
 onnx-weekly
 setuptools>=61.0.0


### PR DESCRIPTION
No longer used