### PR TITLE
Fix license in pyproject.toml | chore(release)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "Microsoft Corporation", email = "onnx@microsoft.com" }]
 urls = { "Repository" = "https://github.com/onnx/onnx-script" }
 readme = "README.md"
 requires-python = ">=3.8"
-license = { text = 'Apache License v2.0' }
+license = { file = "LICENSE" }
 classifiers = [
   "Development Status :: 4 - Beta",
   "Environment :: Console",


### PR DESCRIPTION
It was not the intended license. Now changed to point to the LICENSE file