### PR TITLE
Fix domains for aten_scaled_dot_product_attention | fix(atenlib)

### DIFF
--- a/onnxscript/function_libs/torch_aten/ops/nn.py
+++ b/onnxscript/function_libs/torch_aten/ops/nn.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import math
 from typing import Optional, Sequence
 
-import onnxscript
 from onnxscript import FLOAT, INT64
 from onnxscript.function_libs.torch_aten.registration import torch_op
 from onnxscript.function_libs.torch_aten.tensor_typing import (

--- a/onnxscript/function_libs/torch_aten/ops/nn.py
+++ b/onnxscript/function_libs/torch_aten/ops/nn.py
@@ -1132,7 +1132,7 @@ def aten_rrelu_with_noise_backward(
     raise NotImplementedError()
 
 
-@onnxscript.script()
+@torch_op("aten::scaled_dot_product_attention", private=True)
 def _causal_attention_mask(query: TFloat, key: TFloat) -> TFloat:
     """Create a causal mask for the given query and key tensors.
 
@@ -1160,7 +1160,7 @@ def _causal_attention_mask(query: TFloat, key: TFloat) -> TFloat:
     return attn_mask
 
 
-@onnxscript.script()
+@torch_op("aten::scaled_dot_product_attention", private=True)
 def _attention_scale(query: TFloat) -> TFloat:
     """Calculate the scale factor for the attention result.
 


### PR DESCRIPTION
Previously the functions where not properly registered, causing their domains to become `"this"`

Fixes #608 