### PR TITLE
Make test cases use `onnxscript.testing` | chore(testing)

### DIFF
--- a/onnxscript/converter_test.py
+++ b/onnxscript/converter_test.py
@@ -14,24 +14,19 @@ import unittest
 import warnings
 
 import numpy as np
-import numpy.testing
 import onnx
-import onnxruntime
-from onnx import TensorProto
-from onnx.helper import make_tensor, printable_graph
-from onnx.onnx_cpp2py_export import checker
+import onnxruntime as ort
 from onnxruntime.capi.onnxruntime_pybind11_state import (
     Fail,
     InvalidArgument,
     InvalidGraph,
 )
-from packaging.version import Version
 
+import onnxscript
 import onnxscript.testing
-from onnxscript import OnnxFunction, converter, graph, script, tensor
+from onnxscript import FLOAT, INT64, converter, graph, script, tensor
 from onnxscript.onnx_opset import opset11 as op11
 from onnxscript.onnx_opset import opset15 as op
-from onnxscript.onnx_types import FLOAT, INT64
 from onnxscript.tests.common import onnx_script_test_case, testutils
 
 TEST_INPUT_DIR = pathlib.Path(__file__).parent / "tests" / "models"
@@ -41,8 +36,10 @@ TEST_OUTPUT_DIR = TEST_INPUT_DIR / "testoutputs"
 class TestConverter(testutils.TestBase):
     def validate(self, script):
         if isinstance(script, types.ModuleType):
-            fnlist = [f for f in script.__dict__.values() if isinstance(f, OnnxFunction)]
-        elif isinstance(script, OnnxFunction):
+            fnlist = [
+                f for f in script.__dict__.values() if isinstance(f, onnxscript.OnnxFunction)
+            ]
+        elif isinstance(script, onnxscript.OnnxFunction):
             fnlist = [script]
         else:
             fnlist = script
@@ -61,8 +58,10 @@ class TestConverter(testutils.TestBase):
         skip_check_ort=None,
     ):
         if isinstance(script, types.ModuleType):
-            fnlist = [f for f in script.__dict__.values() if isinstance(f, OnnxFunction)]
-        elif isinstance(script, OnnxFunction):
+            fnlist = [
+                f for f in script.__dict__.values() if isinstance(f, onnxscript.OnnxFunction)
+            ]
+        elif isinstance(script, onnxscript.OnnxFunction):
             fnlist = [script]
         else:
             fnlist = script
@@ -74,13 +73,13 @@ class TestConverter(testutils.TestBase):
                 model = f.to_model_proto(io_types=FLOAT)
                 if save_text:
                     with (TEST_OUTPUT_DIR / f"{f.name}.txt").open("w", encoding="utf-8") as fi:
-                        fi.write(printable_graph(model.graph))
+                        fi.write(onnx.helper.printable_graph(model.graph))
                         for fct in model.functions:
                             fi.write("\n-------------------------\n")
-                            fi.write(printable_graph(fct))
+                            fi.write(onnx.helper.printable_graph(fct))
                 if check_ort and (skip_check_ort is None or f.name not in skip_check_ort):
                     try:
-                        onnxruntime.InferenceSession(model.SerializeToString())
+                        ort.InferenceSession(model.SerializeToString())
                     except (Fail, InvalidGraph, InvalidArgument) as e:
                         raise AssertionError(
                             f"onnxruntime cannot load function " f"{f.name}\n--\n{model}"
@@ -89,13 +88,13 @@ class TestConverter(testutils.TestBase):
                     model = onnx.shape_inference.infer_shapes(model)
                 if save_text:
                     with open(os.path.join(TEST_OUTPUT_DIR, f"{f.name}.shape.txt"), "w") as fi:
-                        fi.write(printable_graph(model.graph))
+                        fi.write(onnx.helper.printable_graph(model.graph))
                         for fct in model.functions:
                             f.write("\n-------------------------\n")
-                            f.write(printable_graph(fct))
+                            f.write(onnx.helper.printable_graph(fct))
                 try:
                     onnx.checker.check_model(model)
-                except checker.ValidationError as e:
+                except onnx.checker.ValidationError as e:
                     if "Field 'shape' of 'type' is required but missing" in str(
                         e
                     ) or "Field 'shape' of type is required but missing" in str(e):
@@ -135,7 +134,7 @@ class TestConverter(testutils.TestBase):
 
         onx = test_functions["eager_op"]
         self.assertIn('name: "fmod"', str(onx))
-        session = onnxruntime.InferenceSession(onx.SerializeToString())
+        session = ort.InferenceSession(onx.SerializeToString())
         y = session.run(None, {"X": x})[0]
         self.assertEqual(y.tolist(), [0.0, 0.5, -0.5])
         # numpy fmod and operator % disagree on this example
@@ -143,7 +142,7 @@ class TestConverter(testutils.TestBase):
         self.assertEqual(res.tolist(), [0.0, 0.5, -0.5])
 
         onx = test_functions["eager_abs"]
-        session = onnxruntime.InferenceSession(onx.SerializeToString())
+        session = ort.InferenceSession(onx.SerializeToString())
         y = session.run(None, {"X": x})[0]
         self.assertEqual(y.tolist(), [1, 6, 3])
         res = eager_op.eager_abs(x)
@@ -174,9 +173,9 @@ class TestConverter(testutils.TestBase):
         x_value_info = model.graph.input[0]
         y_value_info = model.graph.input[1]
         output_value_info = model.graph.output[0]
-        self.assertEqual(x_value_info.type.tensor_type.elem_type, TensorProto.FLOAT)
-        self.assertEqual(y_value_info.type.tensor_type.elem_type, TensorProto.FLOAT)
-        self.assertEqual(output_value_info.type.tensor_type.elem_type, TensorProto.FLOAT)
+        self.assertEqual(x_value_info.type.tensor_type.elem_type, onnx.TensorProto.FLOAT)
+        self.assertEqual(y_value_info.type.tensor_type.elem_type, onnx.TensorProto.FLOAT)
+        self.assertEqual(output_value_info.type.tensor_type.elem_type, onnx.TensorProto.FLOAT)
 
         # Or, use input_types and output_types, as below, for the more general case.
         model = cast_add.to_model_proto(
@@ -185,9 +184,9 @@ class TestConverter(testutils.TestBase):
         x_value_info = model.graph.input[0]
         y_value_info = model.graph.input[1]
         output_value_info = model.graph.output[0]
-        self.assertEqual(x_value_info.type.tensor_type.elem_type, TensorProto.FLOAT)
-        self.assertEqual(y_value_info.type.tensor_type.elem_type, TensorProto.INT64)
-        self.assertEqual(output_value_info.type.tensor_type.elem_type, TensorProto.FLOAT)
+        self.assertEqual(x_value_info.type.tensor_type.elem_type, onnx.TensorProto.FLOAT)
+        self.assertEqual(y_value_info.type.tensor_type.elem_type, onnx.TensorProto.INT64)
+        self.assertEqual(output_value_info.type.tensor_type.elem_type, onnx.TensorProto.FLOAT)
 
     def test_onnxfns1(self):
         from onnxscript.tests.models import onnxfns1
@@ -216,10 +215,6 @@ class TestConverter(testutils.TestBase):
         model = onnx.shape_inference.infer_shapes(model)
         onnx.checker.check_model(model)
 
-    @unittest.skipIf(
-        Version(onnxruntime.__version__) < Version("1.12"),
-        reason="onnxruntime does not support that scenario.",
-    )
     def test_subfunction(self):
         from onnxscript.tests.models import subfunction
 
@@ -354,9 +349,9 @@ class TestConverter(testutils.TestBase):
         self.assertEqual(eager_mode.shape, (5, 3))
         self.assertEqual(eager_mode.dtype, np.float32)
 
-        session = onnxruntime.InferenceSession(f.SerializeToString())
+        session = ort.InferenceSession(f.SerializeToString())
         result = session.run(None, {"A": A})[0]
-        numpy.testing.assert_almost_equal(eager_mode, result)
+        np.testing.assert_almost_equal(eager_mode, result)
 
         f = test_functions["make_sequence_tensor_accumulated"]
 
@@ -365,9 +360,9 @@ class TestConverter(testutils.TestBase):
         self.assertEqual(eager_mode.shape, (5, 3))
         self.assertEqual(eager_mode.dtype, np.float32)
 
-        session = onnxruntime.InferenceSession(f.SerializeToString())
+        session = ort.InferenceSession(f.SerializeToString())
         result = session.run(None, {"A": A})[0]
-        numpy.testing.assert_almost_equal(eager_mode, result)
+        np.testing.assert_almost_equal(eager_mode, result)
 
     def test_loops_break(self):
         from onnxscript.tests.models import loops_break
@@ -379,7 +374,7 @@ class TestConverter(testutils.TestBase):
                 f = test_functions[name]
                 self.assertIn('op_type: "Loop"', str(f))
         onx = test_functions["loop_range_cond"]
-        session = onnxruntime.InferenceSession(onx.SerializeToString())
+        session = ort.InferenceSession(onx.SerializeToString())
         x = np.array([0, 1, 2], dtype=np.float32)
         y = session.run(None, {"A": x})[0]
         self.assertEqual(loops_break.loop_range_cond(x).tolist(), [0.0, 46.0, 92.0])
@@ -399,7 +394,7 @@ class TestConverter(testutils.TestBase):
                 f = test_functions[name]
                 self.assertIn('op_type: "Loop"', str(f))
         onx = test_functions["loop_range_cond_only"]
-        session = onnxruntime.InferenceSession(onx.SerializeToString())
+        session = ort.InferenceSession(onx.SerializeToString())
         x = np.array([0, 1, -2], dtype=np.float32)
         y = session.run(None, {"A": x})[0]
         self.assertEqual(y.tolist(), [0, 10, -20])
@@ -425,7 +420,7 @@ class TestConverter(testutils.TestBase):
         def check_function(x, name, expected, eager=True):
             with self.subTest(name=name):
                 onx = test_functions[name]
-                session = onnxruntime.InferenceSession(onx.SerializeToString())
+                session = ort.InferenceSession(onx.SerializeToString())
                 try:
                     y = session.run(None, {"A": x})[0]
                 except Exception as e:
@@ -479,7 +474,7 @@ class TestConverter(testutils.TestBase):
         def check_function(x, name, expected, eager=True):
             with self.subTest(name=name):
                 onx = test_functions[name]
-                session = onnxruntime.InferenceSession(onx.SerializeToString())
+                session = ort.InferenceSession(onx.SerializeToString())
                 try:
                     y = session.run(None, {"A": x})[0]
                 except Exception as e:
@@ -514,7 +509,9 @@ class TestConverter(testutils.TestBase):
 
     def test_getitem_failure(self):
         def f1(A: FLOAT[...]) -> FLOAT[...]:
-            zero = op.Constant(value=make_tensor("zero", TensorProto.INT64, [1], [0]))
+            zero = op.Constant(
+                value=onnx.helper.make_tensor("zero", onnx.TensorProto.INT64, [1], [0])
+            )
             index = zero, zero + 1
             r = A[index]
             return r
@@ -531,7 +528,7 @@ class TestConverter(testutils.TestBase):
     def check_run(self, onnxfn, inputs, expected_output):
         # Test by converting to model and running with ORT
         model = onnxfn.to_model_proto()
-        session = onnxruntime.InferenceSession(model.SerializeToString())
+        session = ort.InferenceSession(model.SerializeToString())
         input_names = [x.name for x in model.graph.input]
         input_dict = {x: value for (x, value) in zip(input_names, inputs)}
         output = session.run(None, input_dict)[0]

--- a/onnxscript/tests/common/testutils.py
+++ b/onnxscript/tests/common/testutils.py
@@ -8,6 +8,7 @@ import unittest
 
 class TestBase(unittest.TestCase):
     """The base class for testing ONNX Script functions for internal use."""
+
     def validate(self, fn):
         """Validate script function translation."""
         return fn.to_function_proto()

--- a/onnxscript/tests/common/testutils.py
+++ b/onnxscript/tests/common/testutils.py
@@ -7,6 +7,7 @@ import unittest
 
 
 class TestBase(unittest.TestCase):
+    """The base class for testing ONNX Script functions for internal use."""
     def validate(self, fn):
         """Validate script function translation."""
         return fn.to_function_proto()

--- a/onnxscript/tests/common/testutils.py
+++ b/onnxscript/tests/common/testutils.py
@@ -5,19 +5,8 @@
 
 import unittest
 
-from onnxscript import testing
-
 
 class TestBase(unittest.TestCase):
     def validate(self, fn):
         """Validate script function translation."""
         return fn.to_function_proto()
-
-    def assertSame(self, fn1, fn2):
-        testing.assert_isomorphic(fn1, fn2)
-
-    def assertSameGraph(self, graph1, graph2):
-        testing.assert_isomorphic_graph(graph1, graph2)
-
-    def assertSameFunction(self, fn1, fn2):
-        testing.assert_isomorphic_function(fn1, fn2)

--- a/onnxscript/tests/if_test.py
+++ b/onnxscript/tests/if_test.py
@@ -5,12 +5,13 @@
 
 import unittest
 
+import onnxscript.testing
 from onnxscript import script
 from onnxscript.onnx_opset import opset15 as op
 from onnxscript.tests.common import testutils
 
 
-class IfOpTester(testutils.TestBase):
+class IfOpTest(testutils.TestBase):
     def test_no_else(self):
         """Basic test for if-then without else."""
 
@@ -42,8 +43,8 @@ class IfOpTester(testutils.TestBase):
                 result2 = op.Identity(result1)
             return result2
 
-        self.assertSame(if1, if2)
-        self.assertSame(if2, if3)
+        onnxscript.testing.assert_isomorphic_function(if1, if2)
+        onnxscript.testing.assert_isomorphic_function(if2, if3)
 
 
 if __name__ == "__main__":

--- a/onnxscript/tests/loop_test.py
+++ b/onnxscript/tests/loop_test.py
@@ -8,7 +8,7 @@ from onnxscript.onnx_types import FLOAT, INT64
 from onnxscript.tests.common import testutils
 
 
-class LoopOpTester(testutils.TestBase):
+class LoopOpTest(testutils.TestBase):
     def test_loop(self):
         """Basic loop test."""
 

--- a/onnxscript/tests/operator_test.py
+++ b/onnxscript/tests/operator_test.py
@@ -7,13 +7,13 @@ import unittest
 
 import onnx.helper
 
+import onnxscript.testing
 from onnxscript import script
 from onnxscript.onnx_opset import opset15 as op
 from onnxscript.onnx_types import BOOL, FLOAT
-from onnxscript.tests.common import testutils
 
 
-class TestConverter(testutils.TestBase):
+class TestConverter(unittest.TestCase):
     def test_plus_op(self):
         """Test that + is translated to Add op."""
 
@@ -25,7 +25,7 @@ class TestConverter(testutils.TestBase):
         def plus2(x, y):
             return op.Add(x, y)
 
-        self.assertSame(plus1, plus2)
+        onnxscript.testing.assert_isomorphic_function(plus1, plus2)
 
     def test_const_promotion(self):
         """Test promotion of constant literals to TensorProto."""
@@ -40,7 +40,7 @@ class TestConverter(testutils.TestBase):
         def implicit_plus1(A: FLOAT["N"]) -> FLOAT["N"]:  # noqa: F821
             return op.Add(A, 1.0)
 
-        self.assertSame(explicit_plus1, implicit_plus1)
+        onnxscript.testing.assert_isomorphic_function(explicit_plus1, implicit_plus1)
 
     def test_bool_ops_binary(self):
         @script(default_opset=op)
@@ -51,7 +51,7 @@ class TestConverter(testutils.TestBase):
         def onnx_two_or(a: BOOL, b: BOOL) -> BOOL:
             return op.Or(a, b)
 
-        self.assertSame(py_two_or, onnx_two_or)
+        onnxscript.testing.assert_isomorphic_function(py_two_or, onnx_two_or)
 
         @script(default_opset=op)
         def py_two_and(a: BOOL, b: BOOL) -> BOOL:
@@ -61,7 +61,7 @@ class TestConverter(testutils.TestBase):
         def onnx_two_and(a: BOOL, b: BOOL) -> BOOL:
             return op.And(a, b)
 
-        self.assertSame(py_two_and, onnx_two_and)
+        onnxscript.testing.assert_isomorphic_function(py_two_and, onnx_two_and)
 
     def test_bool_ops_three(self):
         @script(default_opset=op)
@@ -72,7 +72,7 @@ class TestConverter(testutils.TestBase):
         def onnx_three_or(a: BOOL, b: BOOL, c: BOOL) -> BOOL:
             return op.Or(op.Or(a, b), c)
 
-        self.assertSame(py_three_or, onnx_three_or)
+        onnxscript.testing.assert_isomorphic_function(py_three_or, onnx_three_or)
 
     def test_bool_ops_four(self):
         @script(default_opset=op)
@@ -83,7 +83,7 @@ class TestConverter(testutils.TestBase):
         def onnx_four_and(a: BOOL, b: BOOL, c: BOOL, d: BOOL) -> BOOL:
             return op.And(op.And(op.And(a, b), c), d)
 
-        self.assertSame(py_four_and, onnx_four_and)
+        onnxscript.testing.assert_isomorphic_function(py_four_and, onnx_four_and)
 
 
 if __name__ == "__main__":

--- a/onnxscript/type_annotation_test.py
+++ b/onnxscript/type_annotation_test.py
@@ -8,13 +8,14 @@ import unittest
 import onnx
 from packaging.version import Version
 
+import onnxscript.testing
 from onnxscript import script
 from onnxscript.onnx_opset import opset15 as op
 from onnxscript.onnx_types import FLOAT
 from onnxscript.tests.common import testutils
 
 
-class TypeAnnotationTester(testutils.TestBase):
+class TypeAnnotationTest(testutils.TestBase):
     def test_type_annotation(self):
         """Test type annotations."""
 
@@ -28,7 +29,7 @@ class TypeAnnotationTester(testutils.TestBase):
                 C = Add (A, B)
             }
         """
-        self.assertSameGraph(static_shape, static_shape_txt)
+        onnxscript.testing.assert_isomorphic_graph(static_shape, static_shape_txt)
 
         @script()
         def symbolic_shape(A: FLOAT["N"], B: FLOAT["N"]) -> FLOAT["N"]:  # noqa: F821
@@ -40,7 +41,7 @@ class TypeAnnotationTester(testutils.TestBase):
                 C = Add (A, B)
             }
         """
-        self.assertSameGraph(symbolic_shape, symbolic_shape_txt)
+        onnxscript.testing.assert_isomorphic_graph(symbolic_shape, symbolic_shape_txt)
 
         @script()
         def tensor_scalar(A: FLOAT["N"], B: FLOAT) -> FLOAT["N"]:  # noqa: F821
@@ -52,7 +53,7 @@ class TypeAnnotationTester(testutils.TestBase):
                 C = Add (A, B)
             }
         """
-        self.assertSameGraph(tensor_scalar, tensor_scalar_txt)
+        onnxscript.testing.assert_isomorphic_graph(tensor_scalar, tensor_scalar_txt)
 
         @script()
         def unknown_rank(A: FLOAT[...], B: FLOAT[...]) -> FLOAT[...]:
@@ -64,7 +65,7 @@ class TypeAnnotationTester(testutils.TestBase):
                 C = Add (A, B)
             }
         """
-        self.assertSameGraph(unknown_rank, unknown_rank_txt)
+        onnxscript.testing.assert_isomorphic_graph(unknown_rank, unknown_rank_txt)
 
         with self.assertRaises(ValueError):
             FLOAT[10][20]  # Invalid usage. pylint: disable=pointless-statement
@@ -89,7 +90,9 @@ class TypeAnnotationTester(testutils.TestBase):
             }
 
         """
-        self.assertSameFunction(bool_type_for_attribute, bool_type_for_attribute_txt)
+        onnxscript.testing.assert_isomorphic_function(
+            bool_type_for_attribute, bool_type_for_attribute_txt
+        )
 
 
 if __name__ == "__main__":

--- a/onnxscript/type_annotation_test.py
+++ b/onnxscript/type_annotation_test.py
@@ -5,9 +5,6 @@
 
 import unittest
 
-import onnx
-from packaging.version import Version
-
 import onnxscript.testing
 from onnxscript import script
 from onnxscript.onnx_opset import opset15 as op
@@ -70,10 +67,6 @@ class TypeAnnotationTest(testutils.TestBase):
         with self.assertRaises(ValueError):
             FLOAT[10][20]  # Invalid usage. pylint: disable=pointless-statement
 
-    @unittest.skipIf(
-        Version(onnx.__version__) < Version("1.13"),
-        reason="module 'onnx.parser' has no attribute 'parse_function'",
-    )
     def test_type_annotation_with_bool_type_for_attribute(self):
         @script()
         def bool_type_for_attribute(self: FLOAT[...], sorted: bool) -> FLOAT[...]:


### PR DESCRIPTION
Clean up test cases. Remove `assertSame*` methods from the TestBase in favor of the public onnxscript.testing module.

- Removed all skips that checks for onnx<1.13 because we now run 1.13 as the lowest version.