### PR TITLE
Add `--no-deps` to release.yaml | chore(release)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
           path: dist
       - name: Install wheel
         run: |
-          python -m pip install dist/*.whl
+          python -m pip install dist/*.whl --no-deps
       - name: Run tests
         run: |
           python -m pytest -v -n auto


### PR DESCRIPTION
Add `--no-deps` to release.yaml so it doesn't reacquire onnx.