### PR TITLE
Update .lintrunner.toml to include a merge base | chore

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1,4 +1,5 @@
 # Configuration for lintrunner https://github.com/suo/lintrunner
+merge_base_with = 'main'
 
 [[linter]]
 code = 'RUFF'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,5 +27,5 @@ pyyaml
 torch>=1.13
 
 # Lint
-lintrunner
+lintrunner>=0.10.7
 lintrunner_adapters>=0.7.0


### PR DESCRIPTION
So running `lintrunner` now means `lintrunner -m main`, which is easier.

https://github.com/suo/lintrunner/commit/75ea9c09cd6904e6e53170af0661fd3dcb39c9e9#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fc