### PR TITLE
Enable string concatenation checks in ruff | chore(lint)

### DIFF
--- a/onnxscript/converter_test.py
+++ b/onnxscript/converter_test.py
@@ -82,7 +82,7 @@ class TestConverter(testutils.TestBase):
                         ort.InferenceSession(model.SerializeToString())
                     except (Fail, InvalidGraph, InvalidArgument) as e:
                         raise AssertionError(
-                            f"onnxruntime cannot load function " f"{f.name}\n--\n{model}"
+                            f"onnxruntime cannot load function {f.name}\n--\n{model}"
                         ) from e
                 if shape_inference:
                     model = onnx.shape_inference.infer_shapes(model)
@@ -423,7 +423,7 @@ class TestConverter(testutils.TestBase):
                     y = session.run(None, {"A": x})[0]
                 except Exception as e:
                     raise AssertionError(
-                        f"Unable to run ONNX for function {name!r} " f"due to {e!r}\n{onx}."
+                        f"Unable to run ONNX for function {name!r} due to {e!r}\n{onx}."
                     ) from e
                 self.assertEqual(y.tolist(), expected)
                 f = getattr(getitem, name)
@@ -477,7 +477,7 @@ class TestConverter(testutils.TestBase):
                     y = session.run(None, {"A": x})[0]
                 except Exception as e:
                     raise AssertionError(
-                        f"Unable to run ONNX for function {name!r} " f"due to {e!r}\n{onx}."
+                        f"Unable to run ONNX for function {name!r} due to {e!r}\n{onx}."
                     ) from e
                 self.assertEqual(y.tolist(), expected)
                 f = getattr(getitem39, name)

--- a/onnxscript/tests/eager_test.py
+++ b/onnxscript/tests/eager_test.py
@@ -22,7 +22,7 @@ def _fft(x, fft_length, axis=-1):
     tr = np.transpose(merged, list(perm))
     if tr.shape[-1] != 2:
         raise AssertionError(
-            f"Unexpected shape {tr.shape}, x.shape={x.shape} " f"fft_length={fft_length}."
+            f"Unexpected shape {tr.shape}, x.shape={x.shape} fft_length={fft_length}."
         )
     return tr
 
@@ -48,7 +48,7 @@ def _ifft(x, fft_length, axis=-1):
     tr = np.transpose(merged, list(perm))
     if tr.shape[-1] != 2:
         raise AssertionError(
-            f"Unexpected shape {tr.shape}, x.shape={x.shape} " f"fft_length={fft_length}."
+            f"Unexpected shape {tr.shape}, x.shape={x.shape} fft_length={fft_length}."
         )
     return tr
 

--- a/opgen/onnx_opset_builder.py
+++ b/opgen/onnx_opset_builder.py
@@ -123,9 +123,7 @@ class OpsetsBuilder:
                 cg.FunctionDef(
                     "__new__",
                     cg.Arg("cls"),
-                    body=cg.ThunkStmt(
-                        f"return Opset.__new__(cls, {domain!r}, {version!r})"
-                    ),
+                    body=cg.ThunkStmt(f"return Opset.__new__(cls, {domain!r}, {version!r})"),
                 ),
                 cg.FunctionDef(
                     "__init__", cg.Arg("self"), body=cg.ThunkStmt("super().__init__()")

--- a/opgen/onnx_opset_builder.py
+++ b/opgen/onnx_opset_builder.py
@@ -124,7 +124,7 @@ class OpsetsBuilder:
                     "__new__",
                     cg.Arg("cls"),
                     body=cg.ThunkStmt(
-                        f"return Opset.__new__(cls, " f"{domain!r}, {version!r})"
+                        f"return Opset.__new__(cls, {domain!r}, {version!r})"
                     ),
                 ),
                 cg.FunctionDef(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ select = [
     "D", # pydocstyle
     "E", # pycodestyle
     "F", # Pyflakes
+    "ISC", # flake8-implicit-str-concat
     "W", # pycodestyle
     "B", # flake8-bugbear
     "N", # pep8-naming


### PR DESCRIPTION
Enable to ISC rules to check to error prone concatenations