### PR TITLE
Enable G and C4 rules in ruff | chore(lint)

### DIFF
--- a/onnxscript/backend/onnx_export.py
+++ b/onnxscript/backend/onnx_export.py
@@ -357,10 +357,7 @@ class Exporter:
                 return self._python_make_node_scan(node, opsets, indent=indent)
             raise RuntimeError(f"Unable to export node type {node.op_type!r} into python.")
         if any(
-            map(
-                lambda att: hasattr(att, "g") and att.g and att.g.ByteSize() > 0,
-                node.attribute,
-            )
+            hasattr(att, "g") and att.g and att.g.ByteSize() > 0 for att in node.attribute
         ):
             raise RuntimeError(f"Unable to export node type {node.op_type!r} into python.")
         ops = {
@@ -438,7 +435,7 @@ def export_template(
     if hasattr(model_onnx, "functions"):
         for f in model_onnx.functions:
             unique_function_domain_version.add((f.domain, 1))
-    unique_function_domain_version_sorted = list(sorted(unique_function_domain_version))
+    unique_function_domain_version_sorted = sorted(unique_function_domain_version)
 
     if rename:
         variable_names: dict[str, str] = {}
@@ -486,7 +483,7 @@ def export_template(
             ts = _translate_type(t.type)
             its = ts.split("[", maxsplit=1)[0]
             unique_types.add(its)
-    context["unique_types"] = list(sorted(unique_types))
+    context["unique_types"] = sorted(unique_types)
 
     # functions
     functions = []

--- a/onnxscript/backend/onnx_export.py
+++ b/onnxscript/backend/onnx_export.py
@@ -356,9 +356,7 @@ class Exporter:
             if node.op_type == "Scan":
                 return self._python_make_node_scan(node, opsets, indent=indent)
             raise RuntimeError(f"Unable to export node type {node.op_type!r} into python.")
-        if any(
-            hasattr(att, "g") and att.g and att.g.ByteSize() > 0 for att in node.attribute
-        ):
+        if any(hasattr(att, "g") and att.g and att.g.ByteSize() > 0 for att in node.attribute):
             raise RuntimeError(f"Unable to export node type {node.op_type!r} into python.")
         ops = {
             "Add": "+",

--- a/onnxscript/converter_test.py
+++ b/onnxscript/converter_test.py
@@ -528,7 +528,7 @@ class TestConverter(testutils.TestBase):
         model = onnxfn.to_model_proto()
         session = ort.InferenceSession(model.SerializeToString())
         input_names = [x.name for x in model.graph.input]
-        input_dict = {x: value for (x, value) in zip(input_names, inputs)}
+        input_dict = dict(zip(input_names, inputs))
         output = session.run(None, input_dict)[0]
         np.testing.assert_equal(output, expected_output)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,20 +106,20 @@ convention = "google"
 [tool.ruff]
 target-version = "py38"
 select = [
+    "B", # flake8-bugbear
+    "C4", # flake8-comprehensions
     "D", # pydocstyle
     "E", # pycodestyle
     "F", # Pyflakes
-    "ISC", # flake8-implicit-str-concat
-    "W", # pycodestyle
-    "B", # flake8-bugbear
-    "C4", # flake8-comprehensions
     "G", # flake8-logging-format
+    "ISC", # flake8-implicit-str-concat
     "N", # pep8-naming
     "NPY", # modern numpy
-    "YTT", # flake8-2020
     "RUF", # Ruff-specific rules
-    "UP", # pyupgrade
     "TID252", # Disallow relative imports
+    "UP", # pyupgrade
+    "W", # pycodestyle
+    "YTT", # flake8-2020
 ]
 ignore = [
     "C408", # Sometime it is preferable when we construct kwargs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ select = [
     "YTT", # flake8-2020
 ]
 ignore = [
-    "C408", # Sometime it is preferable when we construct kwargs
+    "C408", # Sometimes it is preferable when we construct kwargs
     "D1", # D1 is for missing docstrings, which is not yet enforced.
     "D202", # D202 Too strict. "No blank lines allowed after function docstring"
     "D205", # D205 Too strict. "1 blank line required between summary line and description"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ select = [
     "TID252", # Disallow relative imports
 ]
 ignore = [
+    "C408", # Sometime it is preferable when we construct kwargs
     "D1", # D1 is for missing docstrings, which is not yet enforced.
     "D202", # D202 Too strict. "No blank lines allowed after function docstring"
     "D205", # D205 Too strict. "1 blank line required between summary line and description"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,8 @@ select = [
     "ISC", # flake8-implicit-str-concat
     "W", # pycodestyle
     "B", # flake8-bugbear
+    "C4", # flake8-comprehensions
+    "G", # flake8-logging-format
     "N", # pep8-naming
     "NPY", # modern numpy
     "YTT", # flake8-2020


### PR DESCRIPTION
flake8-logging-format (G), flake8-comprehensions (C4)