### PR TITLE
Display name/shape info in TorchScriptTensor | feat(graph_building)

### DIFF
--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -76,7 +76,7 @@ class TorchScriptTensor(onnxscript_tensor.Tensor):
         self._name: Optional[str] = None
 
     def __repr__(self):
-        return f"TorchScriptTensor({self._torch_value!r})"
+        return f"TorchScriptTensor('{self._torch_value!r}')"
 
     @property  # type: ignore[override]
     def value(self) -> Optional[np.ndarray]:

--- a/onnxscript/function_libs/torch_aten/graph_building.py
+++ b/onnxscript/function_libs/torch_aten/graph_building.py
@@ -75,6 +75,9 @@ class TorchScriptTensor(onnxscript_tensor.Tensor):
         self._shape: Optional[Tuple[int | None, ...]] = None
         self._name: Optional[str] = None
 
+    def __repr__(self):
+        return f"TorchScriptTensor({self._torch_value!r})"
+
     @property  # type: ignore[override]
     def value(self) -> Optional[np.ndarray]:
         return self._concrete_value


### PR DESCRIPTION
Create repr so it doesn't show as `TorchScriptTensor(None)`