### PR TITLE
Add permission to the lint job

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,6 +40,8 @@ jobs:
   enforce-style:
     name: Enforce style
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python


### PR DESCRIPTION
Add the `security-events: write` permission to lint for it to be able to upload the sarif file.

https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#example-workflow-for-sarif-files-generated-outside-of-a-repository

Fixes #652